### PR TITLE
style: run cargo fmt for consistent formatting

### DIFF
--- a/.cursor/rules/rust-best-practices/SKILL.md
+++ b/.cursor/rules/rust-best-practices/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: rust-best-practices
+description: >
+  Guide for writing idiomatic Rust code based on Apollo GraphQL's best practices handbook. Use this skill when:
+  (1) writing new Rust code or functions,
+  (2) reviewing or refactoring existing Rust code,
+  (3) deciding between borrowing vs cloning or ownership patterns,
+  (4) implementing error handling with Result types,
+  (5) optimizing Rust code for performance,
+  (6) writing tests or documentation for Rust projects.
+license: MIT
+compatibility: Rust 1.70+, Cargo
+metadata:
+  author: apollographql
+  version: "1.1.0"
+allowed-tools: Bash(cargo:*) Bash(rustc:*) Bash(rustfmt:*) Bash(clippy:*) Read Write Edit Glob Grep
+---
+
+# Rust Best Practices
+
+Apply these guidelines when writing or reviewing Rust code. Based on Apollo GraphQL's [Rust Best Practices Handbook](https://github.com/apollographql/rust-best-practices).
+
+## Best Practices Reference
+
+Before reviewing, familiarize yourself with Apollo's Rust best practices. Read ALL relevant chapters in the same turn in parallel. Reference these files when providing feedback:
+
+- [Chapter 1 - Coding Styles and Idioms](references/chapter_01.md): Borrowing vs cloning, Copy trait, Option/Result handling, iterators, comments
+- [Chapter 2 - Clippy and Linting](references/chapter_02.md): Clippy configuration, important lints, workspace lint setup
+- [Chapter 3 - Performance Mindset](references/chapter_03.md): Profiling, avoiding redundant clones, stack vs heap, zero-cost abstractions
+- [Chapter 4 - Error Handling](references/chapter_04.md): Result vs panic, thiserror vs anyhow, error hierarchies
+- [Chapter 5 - Automated Testing](references/chapter_05.md): Test naming, one assertion per test, snapshot testing
+- [Chapter 6 - Generics and Dispatch](references/chapter_06.md): Static vs dynamic dispatch, trait objects
+- [Chapter 7 - Type State Pattern](references/chapter_07.md): Compile-time state safety, when to use it
+- [Chapter 8 - Comments vs Documentation](references/chapter_08.md): When to comment, doc comments, rustdoc
+- [Chapter 9 - Understanding Pointers](references/chapter_09.md): Thread safety, Send/Sync, pointer types
+
+## Quick Reference
+
+### Borrowing & Ownership
+- Prefer `&T` over `.clone()` unless ownership transfer is required
+- Use `&str` over `String`, `&[T]` over `Vec<T>` in function parameters
+- Small `Copy` types (≤24 bytes) can be passed by value
+- Use `Cow<'_, T>` when ownership is ambiguous
+
+### Error Handling
+- Return `Result<T, E>` for fallible operations; avoid `panic!` in production
+- Never use `unwrap()`/`expect()` outside tests
+- Use `thiserror` for library errors, `anyhow` for binaries only
+- Prefer `?` operator over match chains for error propagation
+
+### Performance
+- Always benchmark with `--release` flag
+- Run `cargo clippy -- -D clippy::perf` for performance hints
+- Avoid cloning in loops; use `.iter()` instead of `.into_iter()` for Copy types
+- Prefer iterators over manual loops; avoid intermediate `.collect()` calls
+
+### Linting
+Run regularly: `cargo clippy --all-targets --all-features --locked -- -D warnings`
+
+Key lints to watch:
+- `redundant_clone` - unnecessary cloning
+- `large_enum_variant` - oversized variants (consider boxing)
+- `needless_collect` - premature collection
+
+Use `#[expect(clippy::lint)]` over `#[allow(...)]` with justification comment.
+
+### Testing
+- Name tests descriptively: `process_should_return_error_when_input_empty()`
+- One assertion per test when possible
+- Use doc tests (`///`) for public API examples
+- Consider `cargo insta` for snapshot testing generated output
+
+### Generics & Dispatch
+- Prefer generics (static dispatch) for performance-critical code
+- Use `dyn Trait` only when heterogeneous collections are needed
+- Box at API boundaries, not internally
+
+### Type State Pattern
+Encode valid states in the type system to catch invalid operations at compile time:
+```rust
+struct Connection<State> { /* ... */ _state: PhantomData<State> }
+struct Disconnected;
+struct Connected;
+
+impl Connection<Connected> {
+    fn send(&self, data: &[u8]) { /* only connected can send */ }
+}
+```
+
+### Documentation
+- `//` comments explain *why* (safety, workarounds, design rationale)
+- `///` doc comments explain *what* and *how* for public APIs
+- Every `TODO` needs a linked issue: `// TODO(#42): ...`
+- Enable `#![deny(missing_docs)]` for libraries

--- a/.cursor/rules/rust-best-practices/references/chapter_01.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_01.md
@@ -1,0 +1,552 @@
+# Chapter 1 - Coding Styles and Idioms
+
+## 1.1 Borrowing Over Cloning
+
+Rust's ownership system encourages **borrow** (`&T`) instead of **cloning** (`T.clone()`). 
+> ❗ Performance recommendation
+
+### ✅ When to `Clone`:
+
+* You need to change the object AND preserve the original object (immutable snapshots).
+* When you have `Arc` or `Rc` pointers.
+* When data is shared across threads, usually `Arc`.
+* Avoid massive refactoring of non performance critical code.
+* When caching results (dummy example below):
+```rust
+fn get_config(&self) -> Config {
+    self.cached_config.clone()
+}
+```
+* When the underlying API expects Owned Data.
+
+### 🚨 `Clone` traps to avoid:
+
+* Auto-cloning inside loops `.map(|x| x.clone)`, prefer to call `.cloned()` or `.copied()` at the end of the iterator.
+* Cloning large data structures like `Vec<T>` or `HashMap<K, V>`.
+* Clone because of bad API design instead of adjusting lifetimes.
+* Prefer `&[T]` instead of `Vec<T>` or `&Vec<T>`.
+* Prefer `&str` or `&String` instead of `String`.
+* Prefer `&T` instead of `T`.
+* Clone a reference argument, if you need ownership, make it explicit in the arguments for the caller. Example:
+```rust
+fn take_a_borrow(thing: &Thing) {
+    let thing_cloned = thing.clone(); // the caller should have passed ownership instead
+}
+```
+
+### ✅ Prefer borrowing:
+```rust
+fn process(name: &str) {
+    println!("Hello {name}");
+}
+
+let user = String::from("foo");
+process(&user);
+```
+
+### ❌ Avoid redundant cloning:
+```rust
+fn process_string(name: String) {
+    println!("Hello {name}");
+}
+
+let user = String::from("foo");
+process(user.clone()); // Unnecessary clone
+```
+
+## 1.2 When to pass by value? (Copy trait)
+
+Not all types should be passed by reference (`&T`). If a type is **small** and it is **cheap to copy**, it is often better to **pass it by value**. Rust makes it explicit via the `Copy` trait.
+
+### ✅ When to pass by value, `Copy`:
+* The type **implements** `Copy` (`u32`, `bool`, `f32`, small structs).
+* The cost of moving the value is negligible.
+
+```rust
+fn increment(x: u32) -> u32 {
+    x + 1
+}
+
+let num = 1;
+let new_num = increment(num); // `num` still usable after this point
+```
+
+### ❓ Which structs should be `Copy`?
+* When to consider declaring `Copy` on your own types:
+* All fields are `Copy` themselves.
+* The struct is `small`, up to 2 (maybe 3) words of memory or 24 bytes (each word is 64 bits/8bytes).
+* The struct **represents a "plain data object"**, without resourcing to ownership (no heap allocations. Example: `Vec` and `Strings`).
+
+❗**Rust Arrays are stack allocated.** Which means they can be copied if their underlying type is `Copy`, but this will be allocated in the program stack which can easily become a stack overflow. More on [Chapter 3 - Stack vs Heap](./chapter_03.md#33-stack-vs-heap-be-size-smart)
+
+For reference, each primitive type size in bytes:
+
+#### Integers:
+
+| Type | Size |
+|------------- |---------- |
+| i8 u8 | 1 byte |
+| i16 u16 | 2 bytes |
+| i32 u32 | 4 bytes |
+| i64 u64 | 8 bytes |
+| isize usize | Arch |
+| i128 u128 | 16 bytes |
+
+#### Floating Point:
+
+| Type | Size |
+|---------- |---------- |
+| f32 | 4 bytes |
+| f64 | 8 bytes |
+
+
+#### Other:
+
+| Type | Size |
+|---------- |---------- |
+| bool | 1 byte |
+| char | 4 bytes |
+
+
+### ✅ Good struct to derive `Copy`:
+```rust
+#[derive(Debug, Copy, Clone)]
+struct Point {
+    x: f32,
+    y: f32,
+    z: f32
+}
+```
+
+### ❌ Bad struct to derive `Copy`:
+```rust
+#[derive(Debug, Clone)]
+struct BadIdea {
+    age: i32,
+    name: String, // String is not `Copy`
+}
+```
+
+### ❓Which Enums should be `Copy`?
+* If your enum acts like tags and atoms.
+* The enum payloads are all `Copy`.
+* **❗Enums size are based on their largest element.**
+
+### ✅ Good Enum to derive
+```rust
+#[derive(Debug, Copy, Clone)]
+enum Direction {
+    North,
+    South,
+    East,
+    West,
+}
+```
+
+## 1.3 Handling `Option<T>` and `Result<T, E>`
+Rust 1.65 introduced a better way to safely unpack Option and Result types with the `let Some(x) = … else { … }` or `let Ok(x) = … else { … }` when you have a default `return` value, `continue` or `break` default else case. It allows early returns when the missing case is **expected and normal**, not exceptional.
+
+### ✅ Cases to use each pattern matching for Option and Return
+* Use `match` when you want to pattern match against the inner types `T` and `E`
+```rust
+match self {
+    Ok(Direction::South) => { … },
+    Ok(Direction::North) => { … },
+    Ok(Direction::East) => { … },
+    Ok(Direction::West) => { … },
+    Err(E::One) => { … },
+    Err(E::Two) => { … },
+}
+
+match self {
+    Some(3|5) => { … }
+    Some(x) if x > 10 => { … }
+    Some(x) => { … }
+    None => { … }
+}
+```
+
+* Use `match` when your type is transformed into something more complex Like `Result<T, E>` becoming `Result<Option<T>, E>`.
+```rust
+match self {
+    Ok(t) => Ok(Some(t)),
+    Err(E::Empty) => Ok(None),
+    Err(err) => Err(err),
+}
+```
+
+* Use `let PATTERN = EXPRESSION else { DIVERGING_CODE; }` when the divergent code doesn't need to know about the failed pattern matches or doesn't need extra computation:
+```rust
+let Some(&Direction::North) = self.direction.as_ref() else {
+    return Err(DirectionNotAvailable(self.direction));
+}
+```
+
+* Use `let PATTERN = EXPRESSION else { DIVERGING_CODE; }` when you want to break or continue a pattern match
+```rust
+for x in self {
+    let Some(x) = x else {
+        continue;
+    }
+}
+```
+
+* Use `if let PATTERN = EXPRESSION else { DIVERGING_CODE; }` when `DIVERGING_CODE` needs extra computation:
+```rust
+if let Some(x) = self.next() {
+    // computation
+} else {
+    // computation when `None/Err` or not matched
+}
+```
+
+❗**If you don't care about the value of the `Err` case, please use `?` to propagate the `Err` to the caller.**
+
+### ❌ Bad Option/Return pattern matching:
+
+* Conversion between Result and Option (prefer `.ok()`,`.ok_or()`, and `ok_or_else()`)
+```rust
+match self {
+    Ok(t) => Some(t),
+    Err(_) => None
+}
+```
+
+* `if let PATTERN = EXPRESSION else { DIVERGING_CODE; }` when divergent code is a default or pre-computed value (prefer `let PATTERN = EXPRESSION else { DIVERGING_CODE; }`):
+```rust
+if let Some(values) = self.next() {
+    // computation
+    (Some(..), values)
+} else {
+    (None, Vec::new())
+}
+```
+
+* Using `unwrap` or `expect` outside tests:
+```rust
+let port = config.port.unwrap();
+```
+
+## 1.4 Prevent Early Allocation
+
+When dealing with functions like `or`, `map_or`, `unwrap_or`, `ok_or`, consider that they have special cases for when memory allocation is required, like creating a new string, creating a collection or even calling functions that manage some state, so they can be replaced with their `_else` counter-part:
+
+### ✅ Good cases
+
+```rust
+let x = None;
+assert_eq!(x.ok_or(ParseError::ValueAbsent), Err(ParseError::ValueAbsent));
+
+let x = None;
+assert_eq!(x.ok_or_else(|| ParseError::ValueAbsent(format!("this is a value {x}"))), Err(ParseError::ValueAbsent));
+
+
+let x: Result<_, &str> = Ok("foo");
+assert_eq!(x.map_or(42, |v| v.len()), 3);
+
+
+let x : Result<_, String> = Ok("foo");
+assert_eq!(x.map_or_else(|e|format!("Error: {e}"), |v| v.len()), 3);
+
+let x = "1,2,3,4";
+assert_eq!(x.parse_to_option_vec.unwrap_or_else(Vec::new), Ok(vec![1, 2, 3, 4]));
+```
+
+### ❌ Bad cases
+
+```rust
+let x : Result<_, String> = Ok("foo");
+assert_eq!(x.map_or(format!("Error with uninformed content"), |v| v.len()), 3);
+
+let x = "1,2,3,4";
+assert_eq!(x.parse_to_option_vec.unwrap_or(Vec::new()), Ok(vec![1, 2, 3, 4])); // could be replaced with `.unwrap_or_default`
+
+let x = None;
+assert_eq!(x.ok_or(ParseError::ValueAbsent(format!("this is a value {x}"))), Err(ParseError::ValueAbsent));
+```
+
+### Mapping Err
+
+When dealing with Result::Err, sometimes is necessary to log and transform the Err into a more abstract or more detailed error, this can be done with `inspect_err` and `map_err`:
+
+```rust
+let x = Err(ParseError::InvalidContent(...));
+
+x
+    .inspect_err(|err| tracing::error!("function_name: {err}"))
+    .map_err(|err| GeneralError::from(("function_name", err)))?;
+```
+
+## 1.5 Iterator, `.iter` vs `for`
+
+First we need to understand a basic loop with each one of them. Let's consider the following problem, we need to sum all even numbers between 0 and 10 incremented by 1:
+
+* `for`:
+```rust
+let mut sum = 0;
+for x in 0..=10 {
+    if x % 2 == 0 {
+        sum += x + 1;
+    }
+}
+```
+
+* `iter`:
+```rust
+let sum: i32 = (0..=10)
+    .filter(|x| x % 2 == 0)
+    .map(|x| x + 1)
+    .sum();
+```
+
+> Both versions do the same thing and are correct and idiomatic, but each shines in different contexts.
+
+### When to prefer `for` loops
+* When you need **early exits** (`break`, `continue`, `return`).
+* **Simple iteration** with side-effects (e.g., logging, IO)
+    * logging can be done correctly in `Iterators` using `inspect` and `inspect_err` functions.
+* When readability matters more than simplicity or chaining.
+
+#### Example:
+```rust
+for value in &mut value {
+    if *value == 0 {
+        break;
+    }
+    *value += fancy_equation();
+}
+```
+
+### When to prefer `iterators` loops (`.iter()` and `.into_iter()`)
+* When you are `transforming collections` or `Option/Results`.
+* You can **compose multiple steps** elegantly.
+* No need for early exits.
+* You need support for indexed values with `.enumerate`.
+```rust
+let values: Vec<_> = vec.into_iter()
+    .enumerate()
+    .filter(|(_index, value)| value % 2 == 0)
+    .map(|(index, value)| value % index)
+    .collect()
+```
+* You need to use collections functions like `.windows` or `chunks`.
+* You need to combine data from multiple sources and don't want to allocate multiple collections.
+* Iterators can be combined with `for` loops:
+```rust
+for value in vec.iter().enumerate()
+    .filter(|(index, value)| value % index == 0) {
+    // ...
+}
+```
+
+> #### ❗REMEMBER: Iterators are Lazy
+>
+> * `.iter`, `.map`, `.filter` don't do anything until you call its consumer, e.g. `.collect`, `.sum`, `.for_each`.
+> * **Lazy Evaluation** means that iterator chains are fused into one loop at compile time.
+
+### 🚨 Anti-patterns to AVOID
+
+* Don't chain without formatting. Prefer each chained function on its own line with the correct indentation (`rustfmt` should take care of this).
+* Don't chain if it makes the code unreadable.
+* Avoid needlessly collect/allocate of a collection (e.g. vector) just to throw it away later by some larger operation or by another iteration.
+* Prefer `iter` over `into_iter` unless you don't need the ownership of the collection.
+* Prefer `iter` over `into_iter` for collections that inner type implements `Copy`, e.g. `Vec<i32>`.
+* For summing numbers prefer `.sum` over `.fold`. `.sum` is specialized for summing values, so the compiler knows it can make optimizations on that front, while fold has a blackbox closure that needs to be applied at every step. If you need to sum by an initial value, just added in the expression `let my_sum = [1, 2, 3].sum() + 3`.
+
+## 1.6 Comments: Context, not Clutter
+
+> "Context are for why, not what or how"
+
+Well-written Rust code, with expressive types and good naming, often speaks for itself. Many high-quality codebases thrive on **few or no comments**. And that's a good thing.
+
+Still, there are **moments where code alone isn't enough** - when there are performance quirks, external constraints, or non-obvious tradeoffs that require a nudge to the reader. In those cases, a concise comment can prevent hours of head-scratching or searching git history.
+
+### ✅ Good comments 
+
+* Safety concerns:
+```rust
+// SAFETY: We have checked that the pointer is valid and non-null. @Function xyz.
+unsafe { std::ptr::copy_nonoverlapping(src, dst, len); }
+```
+
+* Performance quirks:
+```rust
+// This algorithm is a fast square root approximation
+const THREE_HALVES: f32 = 1.5;
+fn q_rsqrt(number: f32 ) -> f32 {
+    let mut i: i32 = number.to_bits() as i32;
+    i = 0x5F375A86_i32.wrapping_sub(i >> 1);
+    let y = f32::from_bits(i as u32);
+    y * (THREE_HALVES - (number * 0.5 * y * y))
+}
+```
+
+* Clear code beats comments. However, when the why isn't obvious, say it plainly - or link to where:
+```rust
+// PERF: Generating the root store per subgraph caused high TLS startup latency on MacOS
+// This works as a caching alternative. See: [ADR-123](link/to/adr-123)
+let subgraph_tls_root_store: RootCertStore = configuration
+    .tls
+    .subgraph
+    .all
+    .create_certificate_store()
+    .transpose()?
+    .unwrap_or_else(crate::services::http::HttpClientService::native_roots_store);
+```
+
+### ❌ Bad comments
+
+* Wall-of-text explanations: long comments and multiline comments
+```rust
+// Lorem Ipsum is simply dummy text of the printing and typesetting industry. 
+// Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, 
+// when an unknown printer took a galley
+fn do_something_odd() {
+    …
+}
+```
+> Prefer `/// doc` comment if it's describing the function.
+
+* Comments that could be better represented as functions or are plain obvious
+```rust
+fn computation() {
+    // increment i by 1
+    i += 1;
+}
+```
+
+### ✅ Breaking up long functions over commenting them
+
+If you find yourself writing a long comment explaining "what", "how" or "each step" in a function, it might be time to split it. So the suggestion is to refactor. This can be beneficial not only for readability, but testability:
+
+#### ❌ Instead of:
+```rust
+fn process_request(request: T) {
+    // We first need to validate request, because of corner case x, y, z
+    // As the payload can only be decoded when they are valid
+    // Then we can perform authorization on the payload
+    // lastly with the authorized payload we can dispatch to handler
+}
+```
+
+#### ✅ Prefer
+```rust
+fn process_request(request: T) -> Result<(), Error> {
+    validate_request_headers(&request)?;
+    let payload = decode_payload(&request);
+    authorize(&payload)?;
+    dispatch_to_handler(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn validate_request_happy_path() { ... }
+
+    #[test]
+    fn validate_request_fails_on_x() { ... }
+
+    #[test]
+    fn validate_request_fails_on_y() { ... }
+
+    #[test]
+    fn decode_validated_request() { ... }
+
+    #[test]
+    fn authorize_payload_xyz() { ... }
+}
+```
+
+Let **structure** and **naming** replace commentary, and enhance its documentation with **tests as living documentation**.
+
+### 📝 TODOs are not comments - track them properly
+
+Avoid leaving lingering `// TODO: Lorem Ipsum` comments in the code. Instead:
+* Turn them into Jira or Github Issues.
+* If needed, to avoid future confusion, reference the issue in the code and the code in the issue.
+
+```rust
+// See issue #123: support hyper 2.0
+```
+
+This helps keeping the code clean and making sure tasks are not forgotten.
+
+### Comments as Living Documentation
+
+There are a few gotchas when calling comments "living documentation":
+* Code evolves.
+* Context changes.
+* Comments get stale.
+* Many large comments make people avoid reading them.
+* Team becomes fearful of delete irrelevant comments.
+
+If you find a comment, **don't trust it blindly**. Read it in context. If it's wrong or outdated, fix or remove it. A misleading comment is worse than no comments at all. 
+
+> Comments should bother you - they demand re-verification, just like stale tests.
+
+When deeper justification is needed, prefer to:
+* **Link to a Design Doc or an ADR**, business logic lives well in design docs while performance tradeoffs live well in ADRs.
+* Move runtime example and usage docs into Rust Docs, `/// doc comment`, where they can be tested and kept up-to-date by tools like `cargo doc`.
+
+> Doc-comments and Doc-testing, `///` and `//!` in [Chapter 8 - Comments vs Documentation](./chapter_08.md)
+
+## 1.7 Use Declarations - "imports"
+
+Different languages have different ways of sorting their imports, in the Rust ecosystem the [standard way](https://github.com/rust-lang/rustfmt/issues/4107) is:
+
+- `std` (`core`, `alloc` would also fit here).
+- External crates (what is in your Cargo.toml `[dependencies]`).
+- Workspace crates (workspace member crates).
+- This module `super::`.
+- This module `crate::`.
+
+```rust
+// std
+use std::sync::Arc;
+
+// external crates
+use chrono::Utc;
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+
+// crate code lives in workspace
+use broker::database::PooledConnection;
+
+// super:: / crate::
+use super::schema::{Context, Payload};
+use super::update::convert_publish_payload;
+use crate::models::Event;
+```
+
+Some enterprise solutions opt to include their core packages after `std`, so all external packages that start with enterprise name are located before the others:
+
+```rust
+// std
+use std::sync::Arc;
+
+// enterprise external crates
+use enterprise_crate_name::some_module::SomeThing;
+
+// external crates
+use chrono::Utc;
+use juniper::{FieldError, FieldResult};
+use uuid::Uuid;
+
+// crate code lives in workspace
+use broker::database::PooledConnection;
+
+// super:: / crate::
+use super::schema::{Context, Payload};
+use super::update::convert_publish_payload;
+use crate::models::Event;
+```
+
+One way of not having to manually control this is using the following arguments in your `rustfmt.toml`:
+
+```toml
+reorder_imports = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+```
+
+> As of Rust version 1.88, it is necessary to execute rustfmt in nightly to correctly reorder code `cargo +nightly fmt`.

--- a/.cursor/rules/rust-best-practices/references/chapter_02.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_02.md
@@ -1,0 +1,117 @@
+# Chapter 2 - Clippy and Linting Discipline
+
+Be sure to have `cargo clippy` installed with your rust compiler, run `cargo clippy -V` in your terminal for a rust project and you should get something like this `clippy 0.1.86 (05f9846f89 2025-03-31)`. If terminal fails to show a clippy version, please run the following code `rustup update && rustup component add clippy`.
+
+Clippy documentation can be found [here](https://doc.rust-lang.org/clippy/usage.html).
+
+## 2.1 Why care about linting?
+
+Rust compiler is a powerful tool that catches many mistakes. However, some more in-depth analysis require extra tools, that is where `cargo clippy` clippy comes into to play. Clippy checks for:
+* Performance pitfalls.
+* Style issues.
+* Redundant code.
+* Potential bugs.
+* Non-idiomatic Rust.
+
+## 2.2 Always run `cargo clippy`
+
+Add the following to your daily workflow:
+
+```shell
+$ cargo clippy --all-targets --all-features --locked -- -D warnings
+```
+
+* `--all-targets`: checks library, tests, benches and examples.
+* `--all-features`: checks code for all features enabled, auto solves conflicting features.
+* `--locked`: Requires `Cargo.lock` to be up-to-date, can be solved with `$ cargo update`.
+* `-D warnings`: treats warnings as errors
+
+Potential additions elements to add:
+
+* `-- -W clippy::pedantic`: lints which are rather strict or have occasional false positives.
+* `-- -W clippy::nursery`: Optionally can be added to check for new lints that are still under development.
+* ❗ Add this to your Makefile, Justfile, xtask or CI Pipeline.
+
+> Example at ApolloGraphQL
+>
+> In the `Router` project there is a `xtask` configured for linting that can be executed with `cargo xtask lint`. 
+
+## 2.3 Important Clippy Lints to Respect
+
+| Lint Name | Why | Link |
+| --------- | ----| -----|
+| `redundant_clone` | Detects unnecessary `clones`, has performance impact | [link (nursery + perf)](https://rust-lang.github.io/rust-clippy/master/#redundant_clone) |
+| `needless_borrow` group | Removes redundant `&` borrowing | [link (style)](https://rust-lang.github.io/rust-clippy/master/#needless_borrow) |
+| `map_unwrap_or` / `map_or` | Simplifies nested `Option/Result` handling | [`map_unwrap_or`](https://rust-lang.github.io/rust-clippy/master/#map_unwrap_or) [`unnecessary_map_or`](https://rust-lang.github.io/rust-clippy/master/#unnecessary_map_or) [`unnecessary_result_map_or_else`](https://rust-lang.github.io/rust-clippy/master/#unnecessary_result_map_or_else) |
+| `manual_ok_or` | Suggest using `.ok_or_else` instead of `match` | [link (style)](https://rust-lang.github.io/rust-clippy/master/#manual_ok_or) |
+| `large_enum_variant` | Warns if an enum has very large variant which is bad for memory. Suggests `Boxing` it | [link (perf)](https://rust-lang.github.io/rust-clippy/master/#large_enum_variant) |
+| `unnecessary_wraps` | If your function always returns `Some` or `Ok`, you don't need `Option`/`Result` | [link (pedantic)](https://rust-lang.github.io/rust-clippy/master/#unnecessary_wraps) |
+| `clone_on_copy` | Catches accidental `.clone()` on `Copy` types like `u32` and `bool` | [link (complexity)](https://rust-lang.github.io/rust-clippy/master/#clone_on_copy) |
+| `needless_collect` | Prevents collecting and allocating an iterator, when allocation is not needed | [link (nursery)](https://rust-lang.github.io/rust-clippy/master/#needless_collect) |
+
+## 2.4 Fix warnings, don't silence them!
+
+**NEVER** just `#[allow(clippy::lint_something)]` unless:
+
+* You **truly understand** why the warning happens and you have a reason why it is better that way.
+* You **document** why it is being ignored.
+* ❗ Don't use `allow`, but `expect`, it will give a warning in case the lint is not true anymore, `#[expect(clippy::lint_something)]`.
+
+### Example:
+
+```rust
+// Faster matching is preferred over size efficiency
+#[expect(clippy::large_enum_variant)]
+enum Message {
+    Code(u8),
+    Content([u8; 1024]),
+}
+```
+
+> The fix would be:
+> 
+> ```rust
+> // Faster matching is preferred over size efficiency
+> #[expect(clippy::large_enum_variant)]
+> enum Message {
+>     Code(u8),
+>     Content(Box<[u8; 1024]>),
+> }
+> ```
+
+### Handling false positives
+
+Sometimes Clippy complains even when your code is correct, in those cases there are two solutions:
+1. Try to refactor the code, so it improves the warning.
+2. **Locally** override the lint with `#[expect(clippy::lint_name)]` and a comment with the reason.
+3. Avoid global overrides, unless it is core crate issue, a good example of this is the Bevy Engine that has a set of lints that should be allowed by default.
+
+## 2.5 Configure workspace/package lints
+
+In your `Cargo.toml` file it is possible to determine which lints and their priorities over each other. In case of 2 or more conflicting lints, the higher priority one will be chosen. Example configuration for a package:
+
+```toml
+[lints.rust]
+future-incompatible = "warn"
+nonstandard_style = "deny"
+
+[lints.clippy]
+all = { level = "deny", priority = 10 }
+redundant_clone = { level = "deny", priority = 9 }
+manual_while_let_some = { level = "deny", priority = 4 }
+pedantic = { level = "warn", priority = 3 }
+```
+
+And for a workspace:
+
+```toml
+[workspace.lints.rust]
+future-incompatible = "warn"
+nonstandard_style = "deny"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = 10 }
+redundant_clone = { level = "deny", priority = 9 }
+manual_while_let_some = { level = "deny", priority = 4 }
+pedantic = { level = "warn", priority = 3 }
+```

--- a/.cursor/rules/rust-best-practices/references/chapter_03.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_03.md
@@ -1,0 +1,209 @@
+# Chapter 3 - Performance Mindset
+
+The **golden rule** of performance work:
+
+> Don't guess, measure.
+
+Rust code is often already pretty fast - don't "optimize" without evidence. Optimize only after finding bottlenecks.
+
+### A good first steps
+* Use `--release` flag on you builds (might sound dummy, but it is quite common to hear people complaining that their Rust code is slower than their X language code, and 99% of the time is because they didn't use the `--release` flag).
+* `$ cargo clippy -- -D clippy::perf` gives you important tips on best practices for performance.
+* [`cargo bench`](https://doc.rust-lang.org/cargo/commands/cargo-bench.html) is a cargo tool to create micro-benchmarks and test different code solutions. Write a test scenario and bench you solution against the original code, if your improvement is larger than 5%, might be a good performance improvement.
+* [`cargo flamegraph`](https://github.com/flamegraph-rs/flamegraph) a powerful profiler for Rust code. For MacOS, [samply](https://github.com/mstange/samply) might be a better DX option.
+
+> #### Further reading on Benchmarking:
+> - [How to build a Custom Benchmarking Harness in Rust](https://bencher.dev/learn/benchmarking/rust/custom-harness/)
+
+
+## 3.1 Flamegraph
+
+Flamegraph helps you visualize how much time CPU spent on each task.
+
+```shell
+# Installing flamegraph
+cargo install flamegraph
+
+# cargo support provided through the cargo-flamegraph binary!
+# defaults to profiling cargo run --release
+cargo flamegraph
+
+# by default, `--release` profile is used,
+# but you can override this:
+cargo flamegraph --dev
+
+# if you'd like to profile a specific binary:
+cargo flamegraph --bin=stress2
+
+# Profile unit tests.
+# Note that a separating `--` is necessary if `--unit-test` is the last flag.
+cargo flamegraph --unit-test -- test::in::package::with::single::crate
+cargo flamegraph --unit-test crate_name -- test::in::package::with::multiple:crate
+
+# Profile integration tests.
+cargo flamegraph --test test_name
+
+# Run criterion benchmark
+# Note that the last --bench is required for `criterion 0.3` to run in benchmark mode, instead of test mode.
+cargo flamegraph --bench some_benchmark --features some_features -- --bench
+
+# Run workspace example
+cargo flamegraph --example some_example --features some_features
+```
+
+> ❗ Always run your profiles with `--release` enabled, the `--dev` flag isn't realistic as it doesn't have optimizations enabled.
+
+The result will look like a flame graph where:
+
+* The `y-axis` shows the **stack depth number**. When looking at a flamegraph, the main function of your program will be closer to the bottom, and the called functions will be stacked on top, with the functions that they call stacked on top of them.
+
+* The `width of each box` shows the **total time that that function** is on the CPU or is part of the call stack. If a function's box is wider than others, that means that it consumes more CPU per execution than other functions, or that it is called more than other functions.
+
+> ❗ The **color of each box** isn't significant, and **is chosen at random**.
+
+### 🚨 Remember
+* Thick stacks: heavy CPU usage
+* Thin stacks: low intensity (cheap)
+
+## 3.2 Avoid Redundant Cloning
+
+> Cloning is cheap... **until it isn't**
+
+In sections [Borrowing over Cloning](./chapter_01.md#11-borrowing-over-cloning) and [Important Clippy lints to respect](./chapter_02.md#23-important-clippy-lints-to-respect) we mentioned the impacts of cloning and the relevant clippy lint [`redundant_clone`](https://rust-lang.github.io/rust-clippy/master/#redundant_clone), so in this section we will explore a bit "when to pass ownership".
+
+* 🚨 If you really need to clone, leave it to the last moment.
+
+### When to pass ownership?
+
+* Only `.clone()` if you truly need a new owned copy. A few examples:
+    * Crate API Design requires owned data.
+    * Have overloaded `std::ops` but still need ownership to the old data:
+    ```rust
+    use std::ops::Add;
+
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    impl Add for Point {
+        type Output = Self;
+
+        fn add(self, other: Self) -> Self {
+            Self {
+                x: self.x + other.x,
+                y: self.y + other.y,
+            }
+        }
+    }
+
+    assert_eq!(Point { x: 1, y: 0 } + Point { x: 2, y: 3 },
+               Point { x: 3, y: 3 });
+    ```
+    * Need to do comparison snapshots or due to API you need multiple owned instances of the data.
+    ```rust
+    fn snapshot(a: &MyValue, b:&MyValue) -> MyValueDiff {
+        a - b
+    }
+
+    impl Sub for MyValue {
+        type Output = MyValueDiff;
+
+        fn sub(self, other: Self) -> MyValue {
+            ...
+        }
+    }
+
+    fn main() {
+        let mut a = MyValue::default();
+        let b = a.clone();
+
+        a.magical_update();
+        println!("{:?}", snapshot(&a, &b));
+    }
+    ```
+* You have reference counted pointers (`Arc, Rc`).
+* You have small structs that are to big to `Copy` but as costly as `std::collections`. An example is HTTP client like `hyper_util::client::legacy::Client` that cloning allows you to share the connection pool.
+* You have a chained struct modifier that needs owned mutation, some **builders** require owned mutation, but most custom builders can be done with `pub fn with_xyz(&mut self, value: Xyz) -> &mut Self`.
+```rust
+// Inline `HashMap` insertion extension
+
+fn insert_owned(mut self, key: K, value: V) -> Self {
+    self.insert(key, value);
+    self
+}
+```
+* Ownership can also be a good way to model business logic / state. For example:
+```rust
+let not_validated: String = ...;// some user source
+let validated = Validate::try_from(not_validated)?;
+// Technically that `try_from` maybe didn't need ownership, but taking it lets us model intent
+```
+
+### When **NOT** to pass ownership?
+
+* Prefer API designs that take reference (`fn process(values: &[T])`), instead of ownership (`fn process(values: Vec<T>)`).
+* If you only need read access to elements, prefer `.iter` or slices:
+```rust
+for item in &some_vec {
+    ...
+}
+```
+* You need to mutate data that is owned by another thread, use `&mut MyStruct`.
+
+### Use `Cow` for `Maybe Owned` data
+
+Sometimes you don't actually need owned data, but that is not clear from the API perspective, so using [`std::borrow::Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html) is a way to efficiently address this case:
+
+```rust
+use std::borrow::Cow;
+
+fn hello_greet(name: Cow<'_, str>) {
+    println!("Hello {name}");
+}
+
+hello_greet(Cow::Borrowed("Julia"));
+hello_greet(Cow::Owned("Naomi".to_string()));
+```
+
+## 3.3 Stack vs Heap: Be size-smart!
+
+### ✅ Good Practices 
+
+* Keep small types (`impl Copy`, `usize`, `bool`, etc) **on the stack**.
+* Avoid passing huge types (`> 512 bytes`) by value or transferring ownership. Prefer pass by reference (e.g. `&T` and `&mut T`).
+* Heap allocate recursive data structures:
+```rust
+enum OctreeNode<T> {
+    Node(T),
+    Children(Box<[Node<T>; 8]>),
+}
+```
+* Return small types by value, types that implement `Copy` or a cheaply Cloned are efficient to return by value (e.g. `struct Vector2 {x: f32, y: f32}`).
+
+### ❗ Be Mindful
+
+* Only use `#[inline]` when benchmark proves beneficial, Rust is already pretty good at inlining **without** hints.
+* Avoid massive stack allocations, box them. Example `let buffer: Box<[u8; 65536]> = Box::new(..)` would first allocate `[u8; 65536]` on the stack then box it, a non-const solution to this would be `let buffer: Box<[u8]> = vec![0; 65536].into_boxed_slice()`.
+* For large `const` arrays, considering using [crate smallvec](https://docs.rs/smallvec/latest/smallvec/) as it behaves like an array, but is smart enough to allocate large arrays on the heap.
+
+## 3.4 Iterators and Zero-Cost Abstractions
+
+Rust iterators are lazy, but eventually compiled away into very efficient tight loops that are only called when consumed. Chaining `.filter()`, `.map()`, `.rev()`, `.skip()`, `.take()`, `.collect()` usually doesn't cost extra and the compiler can reason well enough how to optimize them.
+* Prefer `iterators` over manual `for` loops when working with collections, the compiler can optimize them better than manually doing it.
+* Calling `.iter()` only creates a **reference** to the original collection, this allows you to hold multiple iterators of the same collection.
+
+#### ❗ Avoid creating intermediate collections unless it is really needed:
+
+* Consider that `process` accepts an `iterator`.
+* ❌ BAD - useless intermediate collection:
+```rust
+let doubled: Vec<_> = items.iter().map(|x| x * 2).collect();
+process(doubled);
+```
+* ✅ GOOD - pass the iterator (`fn process(arg: impl Iterator<Item = T>)`):
+```rust
+let doubled_iter = items.iter().map(|x| x * 2);
+process(doubled_iter);
+```

--- a/.cursor/rules/rust-best-practices/references/chapter_04.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_04.md
@@ -1,0 +1,180 @@
+# Chapter 4 - Errors Handling
+
+Rust enforces a strict error handling approach, but *how* you handle them defines where your code feels ergonomic, consistent and safe - as opposing cryptic and painful. This chapter dives into best practices for modeling and managing fallible operations across libraries and binaries.
+
+> Even if you decide to crash you application with `unwrap` or `expect`, Rust forces you to declare that intentionally.
+
+## 4.1 Prefer `Result`, avoid panic 🫨
+
+Rust has a powerful type that wraps fallible data, [`Result<T, E>`](https://doc.rust-lang.org/std/result/), this allows us to handle Error cases according to our needs and manage the state of the application based on that.
+
+* If your function can fail, prefer to return a `Result`:
+```rust
+fn divide(x: f64, y: f64) -> Result<f64, DivisionError> {
+    if y == 0.0 {
+        Err(DivisionError::DividedByZero)
+    } else {
+        Ok(x / y)
+    }
+}
+```
+
+* Use `panic!` only in unrecoverable conditions - typically tests, assertions, bugs or a need to crash the application for some explicit reason.
+* There are 3 relevant macros that can replace `panic!` in appropriate conditions:
+    * `todo!`, similar to panic, but alerts the compiler that you are aware that there is code missing.
+    * `unreachable!`, you have reasoned about the code block and are sure that condition `xyz` is not possible and if ever becomes possible you want to be alerted.
+    * `unimplemented!`, specially useful for alerting that a block is not yet implement with a reason.
+
+## 4.2 Avoid `unwrap`/`expect` in Production
+
+Although `expect` is preferred to `unwrap`, as it can have context, they should be avoided in production code as there are smarter alternatives to them. Considering that, they should be used in the following scenarios:
+- In tests, assertions or test helper functions.
+- When failure is impossible.
+- When the smarter options can't handle the specific case.
+
+### 🚨 Alternative ways of handling `unwrap`/`expect`:
+
+* If your `Result` (or `Option`) can have a predefined early return value in case of `Result::Err`, that doesn't need to know the `Err` value, use `let Ok(..) = else { return ... }` pattern, as it helps with flatten functions:
+```rust
+let Ok(json) = serde_json::from_str(&input) else {
+    return Err(MyError::InvalidJson);
+}
+```
+* If your `Result` (or `Option`) needs error recovery in case of `Result::Err`, that doesn't need to know the `Err` value, use `if let Ok(..) else { ... }` pattern:
+```rust
+if let Ok(json) = serde_json::from_str(&input) else {
+    ...
+} else {
+    Err(do_something_with_input(&input))
+}
+```
+* Functions that can have to handle `Option::None` values are recommended to return `Result<T, E>`, where `E` is a crate or module level error, like the examples above.
+* Lastly `unwrap_or`, `unwrap_or_else` or `unwrap_or_default`, these functions help you create alternative exits to unwrap that manage the uninitialized values.
+
+## 4.3 `thiserror` for Crate level errors
+
+Deriving Error manually is verbose and error prone, the rust ecosystem has a really good crate to help with this, `thiserror`. It allows you to create error types that easily implement `From` trait as well as easy error message (`Display`), improving developer experience while working seamlessly with `?` and integrating with `std::error::Error`:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum MyError {
+    #[error("Network Timeout")]
+    Timeout,
+    #[error("Invalid data: {0}")]
+    InvalidData(String),
+    #[error(transparent)]
+    Serialization(#[from] serde_json::Error),
+    #[error("Invalid request information. Header: {headers}, Metadata: {metadata}")]
+    InvalidRequest {
+        headers: Headers,
+        metadata: Metadata
+    }
+}
+```
+
+### Error Hierarchies and Wrapping
+
+For layered systems the best practice is to use nested `enum/struct` errors with `#[from]`:
+
+```rust
+use crate::database::DbError;
+use crate::external_services::ExternalHttpError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceError {
+    #[error("Database handler error: {0}")]
+    Db(#[from] DbError),
+    #[error("External services error: {0}")]
+    ExternalServices(#[from] ExternalHttpError)
+}
+```
+
+## 4.4 Reserve `anyhow` for Binaries
+
+`anyhow` is an amazing crate, and quite useful for projects that are beginning and need accelerated speed. However, there is a turning point where it just painfully propagates through your code, considering this, `anyhow` is recommended only for **binaries**, where ergonomic error handling is needed and there is no need for precise error types:
+
+```rust
+use anyhow::{Context, Result, anyhow};
+
+fn main() -> Result<()> {
+    let content = std::fs::read_to_string("config.json")
+        .context("Failed to read config file")?;
+    Config::from_str(&content)
+        .map_err(|err| anyhow!("Config parsing error: {err}"))
+}
+```
+
+### 🚨 `Anyhow` Gotchas
+
+* Keeping the `context` and `anyhow` strings up-to-date in all code base is harder than keeping `thiserror` messages as you don't have a single point of entry.
+* `anyhow::Result` erases context that a caller might need, so avoid using it in a library.
+* test helper functions can use `anyhow` with little to no issues.
+
+## 4.5 Use `?` to Bubble Errors
+
+Prefer using `?` over verbose alternatives like `match` chains:
+```rust
+fn handle_request(req: &Request) -> Result<ValidatedRequest, MyError> {
+    validate_headers(req)?;
+    validate_body_format(req)?;
+    validate_credentials(req)?;
+    let body = Body::try_from(req)?;
+
+    Ok(ValidatedRequest::try_from((req, body))?)
+}
+```
+
+> In case error recovery is needed, use `or_else`, `map_err`, `if let Ok(..) else`. To **inspect or log your error**, use `inspect_err`.
+
+## 4.6 Unit Test should exercise errors
+
+While many errors don't implement PartialEq and Eq, making it hard to do direct assertions between them, it is possible to check the error messages with `format!` or `to_string()`, making the errors meaningful and test validated:
+
+```rust
+#[test]
+fn error_does_not_implement_partial_eq() {
+    let err = divide(10., 0.0).unwrap_err();
+    assert_eq!(err.to_string(), "division by zero");
+}
+
+#[test]
+fn error_implements_partial_eq() {
+    let err = process(my_value).unwrap_err();
+
+    assert_eq!(
+        err,
+        MyError {
+            ..
+        }
+    )
+}
+```
+
+## 4.7 Important Topics
+
+### Custom Error Structs
+
+Sometimes you don't need an enum to handle your errors, as there is only one type of error that your module can have. This can be solved with `struct Errors`:
+
+```rust
+#[derive(Debug, thiserror::Error, PartialEq)]
+#[error("Request failed with code `{code}`: {message}")]
+struct HttpError {
+    code: u16,
+    message: String
+}
+```
+
+### Async Errors
+
+When using async runtimes, like Tokio, make sure that your errors implement `Send + Sync + 'static` where needed, specially in tasks or across `.await` boundaries:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ...
+    Ok(())
+}
+```
+
+> Avoid `Box<dyn std::error::Error>` in libraries unless it is really needed

--- a/.cursor/rules/rust-best-practices/references/chapter_05.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_05.md
@@ -1,0 +1,381 @@
+# Chapter 5 - Automated Testing
+
+> Tests are not just for correctness. They are the first place people look to understand how your code works.
+
+* Tests in rust are declared with the attribute macro `#[test]`. Most code editors can compile and run the functions declared under the macro individually or blocks of them.
+* Test can have special compilation flags with `#[cfg(test)]`. Also executable in code editors if it contained `#[test]`, it is a good way to mock complicated functions or override traits.
+
+## 5.1 Tests as Living Documentation
+
+In Rust, as in many other languages, tests often show how the functions are meant to be used. If a test is clear and targeted, it's often more helpful than reading the function body, when combined with other tests, they serve as living documentation.
+
+### Use descriptive names
+
+> In the unit test name we should see the following:
+> * `unit_of_work`: which *function* we are calling. The **action** that will be executed. This is often be the name of the the test `mod` where the function is being tested.
+```rust
+#[cfg(test)] 
+mod test { 
+    mod function_name { 
+        #[test] 
+        fn returns_y_when_x() { ... } 
+    } 
+}
+```
+> * `expected_behavior`: the set of **assertions** that we need to verify that the test works.
+> * `state_that_the_test_will_check`: the general **arrangement**, or setup, of the specific test case.
+
+#### ❌ Don't use a generic name for a test
+```rust
+#[test]
+fn test_add_happy_path() {
+    assert_eq!(add(2, 2), 4);
+}
+```
+#### ✅ Use a name which reads like a sentence, describing the desired behavior
+> Alternatively, if you function has too many tests, you can blob them together in a `mod`, it makes it easier to read and navigate.
+
+```rust
+// OPTION 1
+#[test]
+fn process_should_return_blob_when_larger_than_b() {
+    let a = setup_a_to_be_xyz();
+    let b = Some(2);
+    let expected = MyExpectedStruct { ... };
+
+    let result = process(a, b).unwrap();
+
+    assert_eq!(result, expected);
+}
+
+// OPTION 2
+mod process {
+    #[test]
+    fn should_return_blob_when_larger_than_b() {
+        let a = setup_a_to_be_xyz();
+        let b = Some(2);
+        let expected = MyExpectedStruct { ... };
+
+        let result = process(a, b).unwrap();
+
+        assert_eq!(result, expected);
+    }
+}
+```
+
+> When executing `cargo test` the test output for each option will look like:
+> Option 1: `process_should_return_blob_when_larger_than_b`.
+> Option 2: `process::should_return_blob_when_larger_than_b`.
+
+### Use modules for organization
+
+Most IDEs can run a single module of tests all together.
+The test name in the output will also contain the name of the module.
+Together, that means you can use the module name to group related tests together:
+
+```rust
+#[cfg(test)]
+mod test { // IDEs will provide a ▶️ button here
+
+    mod process {
+        #[test] // IDEs will provide a ▶️ button here
+        fn returns_error_xyz_when_b_is_negative() {
+            let a = setup_a_to_be_xyz();
+            let b = Some(-5);
+            let expected = MyError::Xyz;
+            
+            let result = process(a, b).unwrap_err();
+            
+            assert_eq!(result, expected);
+        }
+
+        #[test] // IDEs will provide a ▶️ button here
+        fn returns_invalid_input_error_when_a_and_b_not_present() {
+            let a = None;
+            let b = None;
+            let expected = MyError::InvalidInput;
+
+            let result = process(a, b).unwrap_err();
+
+            assert_eq!(result, expected);
+        }
+    }
+}
+```
+
+### Only test one behavior per function
+
+To keep tests clear, they should describe _one_ thing that the unit does.
+This makes it easier to understand why a test is failing.
+
+#### ❌ Don't test multiple things in the same test
+```rust
+fn test_thing_parser(...) {
+    assert!(Thing::parse("abcd").is_ok());
+    assert!(Thing::parse("ABCD").is_err());
+}
+```
+
+#### ✅ Test one thing per test
+```rust
+#[cfg(test)]
+mod test_thing_parser {
+    #[test]
+    fn lowercase_letters_are_valid() {
+        assert!(
+            Thing::parse("abcd").is_ok(),
+            // Works like `eprintln`, `format` and `println` macros
+            "Thing parse error: {:?}", 
+            Thing::parse("abcd").unwrap_err()
+        );
+    }
+
+    #[test]
+    fn capital_letters_are_invalid() {
+        assert!(Thing::parse("ABCD").is_err());
+    }
+}
+```
+
+> `Ok` scenarios should have an `eprintln` of the `Err` case.
+
+### Use very few, ideally one, assertion per test
+
+When there are multiple assertions per test, it's both harder to understand the intended behavior and 
+often requires many iterations to fix a broken test, as you work through assertions one by one.
+
+❌ Don't include many assertions in one test:
+
+```rust
+#[test]
+fn test_valid_inputs() {
+    assert!(the_function("a").is_ok());
+    assert!(the_function("ab").is_ok());
+    assert!(the_function("ba").is_ok());
+    assert!(the_function("bab").is_ok());
+}
+```
+
+If you are testing separate behaviors, make multiple tests each with descriptive names.
+To avoid boilerplate, either use a shared setup function or [rstest](https://crates.io/crates/rstest) cases *with descriptive test names*:
+```rust
+#[rstest]
+#[case::single("a")]
+#[case::first_letter("ab")]
+#[case::last_letter("ba")]
+#[case::in_the_middle("bab")]
+fn the_function_accepts_all_strings_with_a(#[case] input: &str) {
+    assert!(the_function(input).is_ok());
+}
+```
+
+> Considerations when using `rstest`
+>
+> * It's harder for both IDEs and humans to run/locate specific tests.
+> * Expectation vs condition naming is now visually inverted (expectation first).
+
+## 5.2 Add Test Examples to your Docs
+
+We will deep dive into docs at a later stage, so in this section we will just briefly go over how to add tests to you docs. Rustdoc can turn examples into executable tests using `///` with a few advantages:
+
+* These tests run with `cargo test` **BUT NOT** `cargo nextest run`. If using `nextest`, make sure to run `cargo t --doc` separately.
+* They serve both as documentation and correctness checks, and are kept up to date by changes, due to the fact that the compiler checks them.
+* No extra testing boilerplate. You can easily hide test sections by prefixing the line with `#`.
+* ❗ There is no issue if you have test duplication between doc-tests and other non-public facing tests.
+
+```rust
+/// Helper function that adds any two numeric values together.
+/// This function reasons about which would be the correct type to parse based on the type
+/// and the size of the numeric value.
+/// 
+/// # Examples
+/// 
+/// ```rust
+/// # use crate_name::generic_add;
+/// use num::numeric;
+/// 
+/// # assert_eq!(
+/// generic_add(5.2, 4) // => 9.2
+/// # , 9.2)
+/// 
+/// # assert_eq!(
+/// generic_add(2, 2.0) // => 4
+/// # , 4)
+/// ```
+```
+
+This documentation code would look like:
+```rust
+use num::numeric;
+
+generic_add(5.2, 4) // => 9.2
+generic_add(2, 2.0) // => 4
+```
+
+## 5.3 Unit Test vs Integration Tests vs Doc tests
+
+As a general rule, without delving into *test pyramid naming*, rust has 3 sets of tests:
+
+### Unit Test
+
+Tests that go in the **same module** as the **tested unit** was declared, this allows the test runner to have visibility over private functions and parent `use` declarations. They can also consume `pub(crate)` functions from other modules if needed. Unit tests can be more focused on **implementation and edge-cases checks**.
+
+* They should be as simple as possible, testing one state and one behavior of the unit. KISS.
+* They should test for errors and edge cases.
+* Different tests of the same unit can be combined under a single `#[cfg(test)] mod test_unit_of_work {...}`, allowing multiple submodules for different `units_of_work`.
+* Try to keep external states/side effects to your API to minimum and focus those tests on the `mod.rs` files.
+* Tests that are not yet fully implemented can be ignored with the `#[ignore = "optional message"]` attribute.
+* Tests that intentionally panic should be annotated with the attribute `#[should_panic]`.
+
+```rust
+#[cfg(test)]
+mod unit_of_work_tests {
+    use super::*;
+
+    #[test]
+    fn unit_state_behavior() {
+        let expected = ...;
+        let result = ...;
+        assert_eq!(result, expected, "Failed because {}", result - expected);
+    }
+}
+```
+
+### Integration Tests
+
+Tests that go under the `tests/` directory, they are entirely external to your library and use the same code as any other code would use, not have access to private and crate level functions, which means they can **only test** functions on your **public API**. 
+
+> Their purpose is to test whether many parts of the code work together correctly, units of code that work correctly on their own could have problems when integrated.
+
+* Test for happy paths and common use cases.
+* Allow external states and side effects, [testcontainers](https://rust.testcontainers.org/) might help.
+* if testing binaries, try to break **executable** and **functions** into `src/main.rs` and `src/lib.rs`, respectively.
+
+```
+├── Cargo.lock 
+├── Cargo.toml 
+├── src 
+│   └── lib.rs 
+└── tests 
+    ├── mod.rs 
+    ├── common 
+    │   └── mod.rs 
+    └── integration_test.rs
+```
+
+### Doc Testing
+
+As mentioned in section [5.2](#52-add-test-examples-to-your-docs), doc tests should have happy paths, general public API usage and more powerful attributes that improve documentation, like custom CSS for the code blocks.
+
+### Attributes:
+
+* `ignore`: tells rust to ignore the code, usually not recommended, if you want just a code formatted text, use `text`.
+* `should_panic`: tells the rust compiler that this example block will panic.
+* `no_run`: compiles but doesn't execute the code, similar to `cargo check`. Very useful when dealing with side-effects for documentation.
+* `compile_fail`: Test rustdoc that this block should cause a compilation fail, important when you want to demonstrate wrong use cases.
+
+## 5.4 How to `assert!`
+
+Rust comes with 2 macros to make assertions:
+* `assert!` for asserting boolean values like `assert!(value.is_ok(), "'value' is not Ok: {value:?}")`
+* `assert_eq!` for checking equality between two different values, `assert_eq!(result, expected, "'result' differs from 'expected': {}", result.diff(expected))`.
+
+### 🚨 `assert!` reminders
+* Rust asserts support formatted strings, like the previous examples, those strings will be printed in case of failure, so it is a good practice to add what the actual state was and how it differs from the expected.
+* If you don't care about the exact pattern matching value, using `matches!` combined with `assert!` might be a good alternative.
+```rust
+assert!(matches!(error, MyError::BadInput(_), "Expected `BadInput`, found {error}"));
+```
+* Use `#[should_panic]` wisely. It should only be used when panic is the desired behavior, prefer result instead of panic.
+* There are some other that can enhance your testing experience like:
+    * [`rstest`](https://crates.io/crates/rstest): fixture based test framework with procedural macros.
+    * [`pretty_assertions`](https://crates.io/crates/pretty_assertions): overrides `assert_eq` and `assert_ne`, and creates colorful diffs between them.
+
+## 5.5 Snapshot Testing with `cargo insta`
+
+> When correctness is visual or structural, snapshots tell the story better than asserts.
+
+1. Add to your dependencies:
+```toml
+insta = { version = "1.42.2", features = ["yaml"] }
+```
+> For most real world applications the recommendation is to use YAML snapshots of serializable values. This is because they look best under version control and the diff viewer and support redaction. To use this enable the yaml feature of insta.
+
+2. For a better review experience, add the CLI `cargo install cargo-insta`.
+
+3. Writing a simple test:
+```rust
+fn split_words(s: &str) -> Vec<&str> {
+    s.split_whitespace().collect()
+}
+
+#[test]
+fn test_split_words() {
+    let words = split_words("hello from the other side");
+    insta::assert_yaml_snapshot!(words);
+}
+```
+
+4. Run `cargo insta test` to execute, and `cargo insta review` to review conflicts.
+
+To learn more about `cargo insta` check out its [documentation](https://insta.rs/docs/quickstart/) as it is a very complete and well documented tool.
+
+### What is snapshot testing?
+
+Snapshot testing compares your output (text, Json, HTML, YAML, etc) against a saved "golden" version. On future runs, the test fails if the output changes, unless humanly approved. It is perfect for:
+* Generate code.
+* Serializing complex data.
+* Rendered HTML.
+* CLI output.
+
+#### ❌ What not to test with snapshot
+* Very stable, numeric-only or small structured data associated logic (prefer `assert_eq!`).
+* Critical path logic (prefer precise unit tests).
+* Flaky tests, randomly generated output, unless redacted.
+* Snapshots of external resources, use mocks and stubs.
+
+## 5.6 ✅ Snapshot Best Practices
+
+* Named snapshots, it gives meaningful snapshot files names, e.g. `snapshots/this_is_a_named_snapshot.snap`
+```rust
+assert_snapshot!("this_is_a_named_snapshot", output);
+```
+
+* Keep snapshots small and clear. 
+```rust
+// ✅ Best case:
+assert_snapshot!("app_config/http", whole_app_config.http);
+
+// ❌ Worst case:
+assert_snapshot!("app_config", whole_app_config); // Huge object
+```
+
+> #### 🚨 Avoid snapshotting huge objects 
+> Huge objects become hard to review and reason about.
+
+* Avoid snapshotting simple types (primitives, flat enums, small structs):
+```rust
+// ✅ Better:
+assert_eq!(meaning_of_life, 42);
+
+// ❌ OVERKILL:
+assert_snapshot!("the_meaning_of_life", meaning_of_life); // meaning_of_life == 42
+```
+
+* Use [redactions](https://insta.rs/docs/redactions/) for unstable fields (randomly generated, timestamps, uuid, etc):
+```rust
+use insta::assert_json_snapshot;
+
+#[test]
+fn endpoint_get_user_data() {
+    let data = http::client.get_user_data();
+    assert_json_snapshot!(
+        "endpoints/subroute/get_user_data",
+        data,
+        ".created_at" => "[timestamp]",
+        ".id" => "[uuid]"
+    );
+}
+```
+* Commit your snapshots into git. They will be stored in `snapshots/` alongside your tests.
+* Review changes carefully before accepting.

--- a/.cursor/rules/rust-best-practices/references/chapter_06.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_06.md
@@ -1,0 +1,161 @@
+# Chapter 6 - Generics, Dynamic Dispatch and Static Dispatch
+
+> Static where you can, dynamic where you must
+
+Rust allows you to handle polymorphic code in two ways:
+* **Generics / Static Dispatch**: compile-time, monomorphized per use.
+* **Trait Objects / Dynamic Dispatch**: runtime vtable, single implementation.
+
+Understanding the trade-offs lets you write faster, smaller and more flexible code.
+
+## 6.1 [Generics](https://doc.rust-lang.org/book/ch10-00-generics.html)
+
+Every programming language has tools for effectively handling the duplication of concepts. In Rust, one such tool is generics: abstract stand-ins for concrete types or other properties. We can express the behavior of generics or how they relate to other generics without knowing what will be in their place when compiling and running the code. 
+
+We use generics to create definitions for items like function signatures or structs, which we can then use with many different concrete data types. Let's first look at how to define functions, structs, enums, and methods using generics. Generics can also be used to implement Type State Pattern and constrain a struct functionality to certain expected types, more on type state on [Chapter 7](./chapter_07.md).
+
+[Generics by Examples](https://doc.rust-lang.org/rust-by-example/generics.html).
+
+### Generics Performance
+
+You might be wondering whether there is a runtime cost when using generic type parameters. The good news is that using generic types won't make your program run any slower than it would with concrete types. Rust accomplishes this by performing monomorphization of the code using generics at compile time. Monomorphization is the process of turning generic code into specific code by filling in the concrete types that are used when compiled. The compiler checks for all occurrences of the generic parameter and generates code for the concrete types the generic code is called with.
+
+## 6.2 Static Dispatch: `impl Trait` or `<T: Trait>`
+
+A static dispatch is basically a constrained version of a generics, a trait bounded generic, at compile-time it is able to check if your generic satisfies the declared traits.
+
+### ✅ Best when:
+* You want **zero runtime cost**, by paying the compile time cost.
+* You need **tight loops or performance**.
+* Your types are **known at compile time**.
+* Your are working with **single-use implementations** (monomorphized).
+
+### 🏎️ Example: High-performance function with generic
+```rust
+fn specialized_sum<T: MyTrait, U: Iterator<Item = T>>(iter: U) -> T {
+    iter.map(|x| x.random_mapping()).sum()
+}
+
+// or, equivalent, more modern
+fn specialized_sum<T: MyTrait>(iter: impl Iterator<Item = T>) -> T {
+    iter.map(|x| x.random_mapping()).sum()
+}
+```
+
+This is compiled into **specialized machine code** for each usage, fast and inlined.
+
+## 6.3 Dynamic Dispatch: `dyn Trait`
+
+Usually dynamic dispatch is used with some kind of pointer or a reference, like `Box<dyn Trait>`, `Arc<dyn Trait>` or `&dyn trait`.
+
+### ✅ Best when:
+* You absolutely need runtime polymorphism.
+* You need to **store different implementations** in one collection.
+* You want to **abstract internals behind a stable interface**.
+* You are writing a **plugin-style architecture**.
+
+> ❗ Closer to what you would get in an object oriented language and can have some heavy costs associated to it. Can avoid generic entirely and let you mix types that implement the same traits.
+
+### 🚚 Example: Heterogeneous collection
+
+```rust
+trait Animal {
+    fn greet(&self) -> String;
+}
+
+struct Dog;
+impl Animal for Dog {
+    fn greet(&self) -> String {
+        "woof".to_string()
+    }
+}
+
+struct Cat;
+impl Animal for Cat {
+    fn greet(&self) -> String {
+        "meow".to_string()
+    }
+}
+
+fn all_animals_greeting(animals: Vec<Box<dyn Animal>>) {
+    for animal in animals {
+        println!("{}", animal.greet())
+    }
+}
+```
+
+## 6.4 Trade-off summary
+
+| | Static Dispatch (impl Trait) | Dynamic Dispatch (dyn Trait) |
+|------------------- |------------------------------ |---------------------------------- |
+| Performance | ✅ Faster, inlined | ❌ Slower: vtable indirection |
+| Compile time | ❌ Slower: monomorphization | ✅ Faster: shared code |
+| Binary size | ❌ Larger: per-type codegen | ✅ Smaller |
+| Flexibility | ❌ Rigid, one type at a time | ✅ Can mix types in collections |
+| Use in trait fn() | ❌ Traits must be object-safe | ✅ Works with trait objects |
+| Errors | ✅ Clearer | ❌ Erased types can confuse errors |
+
+* Prefer generics/static dispatch when you control the call site and want performance.
+* Use dynamic dispatch when you need abstraction, plugins or mixed types. 🚨 Runtime cost.
+* If you are not sure, start with generics, trait bound them - then use `Box<dyn Trait>` when flexibility outweighs speed.
+
+> Favor static dispatch until your trait needs to live behind a pointer.
+
+## 6.5 Best Practices for Dynamic Dispatch
+
+Dynamic dispatch `Ptr<dyn Trait>` is a powerful tool, but it also has significant performance trade-offs. You should only reach for it when **type erasure or runtime polymorphism** are essential. It is important to know when you need Trait Objects:
+
+### ✅ Use Dynamic Dispatch When:
+
+* You need heterogeneous types in a collection:
+```rust
+fn all_animals_greeting(animals: Vec<Box<dyn Animal>>) {
+    for animal in animals {
+        println!("{}", animal.greet())
+    }
+}
+```
+
+* You want runtime plugins or hot-swappable components.
+* You want to abstract internals from the caller (library design).
+
+
+### ❌ Avoid Dynamic Dispatch When:
+
+* You control the concrete types.
+* You are writing code in performance critical paths.
+* You can express the same logic in other ways while keeping simplicity, e.g. generics.
+
+## 6.6 🚨 Trait Objects Ergonomics
+
+* Prefer `&dyn Trait` over `Box<dyn Trait>` when you don't need ownership.
+* Use `Arc<dyn Trait>` for shared access across threads.
+* Don't use `dyn Trait` if the trait has methods that return `Self`.
+* **Avoid boxing too early**. Don't box inside structs unless you are sure it'll be beneficial or is required (recursive).
+```rust
+// ✅ Use generics when possible
+struct Renderer<B: Backend> {
+    backend: B
+}
+
+// ❌ Premature Boxing
+struct Renderer {
+    backend: Box<dyn Backend> // Boxing too early
+}
+```
+* If you must expose a `dyn trait` in a public API, `Box` at the boundary, not internally.
+* **Object Safety**: You can only create `dyn Traits` from object-safe traits:
+    * It has **no generic methods**.
+    * It doesn't require `Self: Sized`.
+    * All method signatures use `&self`, `&mut self` or `self`.
+    ```rust
+    // ✅ Object Safe
+    trait Runnable {
+        fn run(&self);
+    }
+
+    // ❌ Not Object Safe
+    trait Factory {
+        fn create<T>() -> T; // generic methods are not allowed
+    }
+    ```

--- a/.cursor/rules/rust-best-practices/references/chapter_07.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_07.md
@@ -1,0 +1,226 @@
+# Chapter 7 - Type State Pattern
+
+Models state at compile time, preventing bugs by making illegal states unrepresentable. It takes advantage of the Rust generics and type system to create sub-types that can only be reached if a certain condition is achieved, making some operations illegal at compile time. 
+
+> Recently it became the standard design pattern of Rust programming. However, it is not exclusive to Rust, as it is achievable and has inspired other languages to do the same [swift](https://swiftology.io/articles/typestate/) and [typescript](https://catchts.com/type-state).
+
+## 7.1 What is Type State Pattern?
+
+**Type State Pattern** is a design pattern where you encode different **states** of the system as **types**, not as runtime flags or enums. This allows the compiler to enforce state transitions and prevent illegal actions at compile time. It also improves the developer experience, as developers only have access to certain functions based on the state of the type.
+
+> Invalid states become compile errors instead of runtime bugs.
+
+## 7.2 Why use it?
+
+* Avoids runtime checks for state validity. If you reach certain states, you can make certain assumptions of the data you have.
+* Models state transitions as type transitions. This is similar to a state machine, but in compile time.
+* Prevents data misuse, e.g. using uninitialized objects.
+* Improves API safety and correctness.
+* The phantom data field is removed after compilation so no extra memory is allocated.
+
+## 7.3 Simple Example: File State
+
+[Github Example](https://github.com/apollographql/rust-best-practices/tree/main/examples/simple-type-state)
+```rust
+use std::{io, path::{Path, PathBuf}};
+
+struct FileNotOpened;
+struct FileOpened;
+
+#[derive(Debug)]
+struct File<State> {
+    /// Path to the opened file
+    path: PathBuf,
+    /// Open `File` handler
+    handle: Option<std::fs::File>,
+    /// Type state manager
+    _state: std::marker::PhantomData<State>
+}
+
+impl File<FileNotOpened> {
+    /// `open` is the only entry point for this struct.
+    /// * When called with a valid path, it will return a `File<FileOpened>` with a valid `handler` and `path`
+    /// * `open` serves as an alternative to `new` and `defaults` methods (usable when your struct needs valid data to exist).
+    fn open(path: &Path) -> io::Result<File<FileOpened>> {
+        // If file is invalid, it will return `std::io::Error`
+        let file = std::fs::File::open(path)?;
+        Ok(
+            File {
+                path: path.to_path_buf(),
+                // Always valid
+                handle: Some(file),
+                _state: std::marker::PhantomData::<FileOpened>
+            }
+        )
+    }
+}
+
+impl File<FileOpened> {
+    /// Reads the content of the `File` as a `String`.
+    /// `read` can only be called by state `File<FileOpened>`
+    fn read(&mut self) -> io::Result<String> {
+        use io::Read;
+
+        let mut content = String::new();
+        let Some(handle)= self.handle.as_mut() else {
+            unreachable!("Safe to unwrap as state can only be reached when file is open");
+        };
+        handle.read_to_string(&mut content)?;
+        Ok(content)
+    }
+
+    /// Returns the valid path buffer.
+    fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+```
+
+## 7.4 Real-World Examples
+
+### Builder Pattern with Compile-Time Guarantees
+
+> Forces the user to **set required fields** before calling `.build()`.
+
+[Github Example](https://github.com/apollographql/rust-best-practices/tree/main/examples/type-state-builder)
+
+A type-state pattern can have more than one associated states:
+
+```rust
+use std::marker::PhantomData;
+
+struct MissingName;
+struct NameSet;
+struct MissingAge;
+struct AgeSet;
+
+#[derive(Debug)]
+struct Person {
+    name: String,
+    age: u8,
+    email: Option<String>,
+}
+
+struct Builder<NameState, AgeState> {
+    name: Option<String>,
+    age: u8,
+    email: Option<String>,
+    _name_marker: PhantomData<NameState>,
+    _age_marker: PhantomData<AgeState>,
+}
+
+impl Builder<MissingName, MissingAge> {
+    fn new() -> Self {
+        Builder { name: None, age: 0, _name_marker: PhantomData, _age_marker: PhantomData, email: None }
+    }
+
+    fn name(self, name: String) -> Builder<NameSet, MissingAge> {
+        Builder { name: Some(name), _name_marker: PhantomData::<NameSet>, age: self.age, _age_marker: PhantomData, email: None }
+    }
+
+    fn age(self, age: u8) -> Builder<MissingName, AgeSet> {
+        Builder { age, _age_marker: PhantomData::<AgeSet>, name: None, _name_marker: PhantomData, email: None }
+    }
+}
+
+impl Builder<NameSet, MissingAge> {
+    fn age(self, age: u8) -> Builder<NameSet, AgeSet> {
+        Builder { age, _age_marker: PhantomData::<AgeSet>, name: self.name, _name_marker: PhantomData::<NameSet>, email: None }
+    }
+}
+
+impl Builder<MissingName, AgeSet> {
+    fn email(self, email: String) -> Self {
+        Self { name: self.name , age: self.age , email: Some(email) , _name_marker: self._name_marker , _age_marker: self._age_marker }
+    }
+
+    fn name(self, name: String) -> Builder<NameSet, AgeSet> {
+        Builder { name: Some(name), _name_marker: PhantomData::<NameSet>, age: self.age, _age_marker: PhantomData::<AgeSet>, email: self.email }
+    }
+}
+
+impl Builder<NameSet, AgeSet> {
+    fn build(self) -> Person {
+        Person { 
+            name: self.name.unwrap_or_else(|| unreachable!("Name is guarantee to be set")), 
+            age: self.age,
+            email: self.email,
+        }
+    }
+}
+```
+
+Although a bit more verbose than a usual builder, this guarantees that all necessary fields are present (note that e-mail is optional field only present in the final builder).
+
+#### Usage:
+```rust
+// ✅ Valid cases
+let person: Person = Builder::new().name("name".to_string()).age(30).build();
+let person: Person = Builder::new().age(30).name("name".to_string()).build();
+let person: Person = Builder::new().age(30).name("name".to_string()).email("myself@email.com".to_string()).build();
+
+// ❌ Invalid cases
+let person: Person = Builder::new().name("name".to_string()).build(); // ❌ Compile error: Age required to `build`
+let person: Person = Builder::new().age(30).build(); // ❌ Compile error: Name required to `build`
+let person: Person = Builder::new().age(30).email("myself@email.com".to_string()).build(); // ❌ Compile error: Name required to `build`
+let person: Person = Builder::new().build();// ❌ Compile error: Name and Age required to `build`
+```
+
+### Network Protocol State Machine
+
+Illegal transitions like sending a message before connecting **simply don't compile**:
+
+```rust
+// Mock example
+struct Disconnected;
+struct Connected;
+
+struct Client<State> {
+    stream: Option<std::net::TcpStream>,
+    _state: std::marker::PhantomData<State>
+}
+
+impl Client<Disconnected> {
+    fn connect(addr: &str) -> std::io::Result<Client<Connected>> {
+        let stream = std::net::TcpStream::connect(addr)?;
+        Ok(Client {
+            stream: Some(stream),
+            _state: std::marker::PhantomData::<Connected>
+        })
+    }
+}
+
+impl Client<Connected> {
+    fn send(&mut self, msg: &str) {
+        use std::io::Write;
+        let Some(stream) = self.stream.as_mut() else {
+            unreachable!("Stream is guarantee to be set");
+        };
+        stream.write_all(msg.as_bytes())
+    }
+}
+```
+
+## 7.5 Pros and Cons
+
+### ✅ Use Type-State Pattern When:
+* Your want **compile-time state safety**.
+* You need to enforce **API constraints**.
+* You are writing a library/crate that is heavy dependent on variants.
+* Your want to replace runtime booleans or enums with **type-safe code paths**.
+* You need compile time correctness.
+
+### ❌ Avoid it when:
+* Writing trivial states like enums.
+* Don't need type-safety.
+* When it leads to overcomplicated generics.
+* When runtime flexibility is required.
+
+### 🚨 Downsides and Cautions
+* Can lead to more **verbose solutions**.
+* Can lead to **complex type signatures**.
+* May require **unsafe** to return **variant outputs** based on different states.
+* May required a bunch of duplication (e.g. same struct field reused).
+* PhantomData is not intuitive for beginners and can feel a bit hacky.
+
+> Use this pattern when it **saves bugs, increases safety or simplifies logic**, not just for cleverness.

--- a/.cursor/rules/rust-best-practices/references/chapter_08.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_08.md
@@ -1,0 +1,254 @@
+# Chapter 8 - Comments vs Documentation
+
+> Clear code beats clear comments. However, when the why isn't obvious, comment it plainly - or link to where you can read more context.
+
+## 8.1 Comments vs Documentation: Know the Difference
+
+| Purpose | Use `// comment` | Use `/// doc` or `//! crate doc` |
+|-------------- |------------------------------------------- |---------------------------------------------------------------- |
+| Describe Why | ✅ Yes - explains tricky reasoning | ❌ Not for documentation |
+| Describe API | ❌ Not useful | ✅ Yes - public interfaces, usage, details, errors, panics |
+| Maintainable | 🚨 Often becomes obsolete and hard to reason | ✅ Tied to code, appears in generated docs and can run test cases |
+| Visibility | Local development only | Exported to users and tools like `cargo doc` |
+
+## 8.2 When to use comments
+
+Use `//` comments (double slashed) when something can't be expressed clearly in code, like:
+* **Safety Guarantees**, some of which can be better expressed with code conditionals.
+* Workarounds or **Optimizations**.
+* Legacy or **platform-specific** behaviors. Some of them can be expressed with `#[cfg(..)]`.
+* Links to **Design Docs** or **ADRs**.
+* Assumptions or **gotchas** that aren't obvious.
+
+> Name your comments! For example, a comment regarding a safety guarantee should start with `// SAFETY: ...`.
+
+### ✅ Good comment:
+```rust
+// SAFETY: `ptr` is guaranteed to be non-null and aligned by caller
+unsafe { std::ptr::copy_nonoverlapping(src, dst, len); }
+```
+
+### ✅ Design context comment:
+```rust
+// CONTEXT: Reuse root cert store across subgraphs to avoid duplicate OS calls:
+// [ADR-12](link/to/adr-12): TLS Performance on MacOS
+```
+
+## 8.3 When comments get in the way
+
+Avoid comments that:
+* Restate obvious things (`// increment i by 1 for the next loop`).
+* Can grow stale over time.
+* `TODO`s without actions (links to some versioned issue).
+* Could be replaced by better naming or smaller functions.
+
+### ❌ Bad comment:
+```rust
+fn compute(counter: &mut usize) {
+    // increment by 1
+    *counter += 1;
+}
+```
+
+### ❌ Too long or outdated
+```rust
+// Originally written in 2028 for some now-defunct platform
+```
+
+## 8.4 Don't Write Living Documentation (living comments)
+
+Comments as a "living documentation" is a **dangerous myth**, as comments are **not free**:
+* They **rot** - nobody compiles comments.
+* They **mislead** - readers usually assume they are true with no critique, e.g. "the other developer knows this code better than I do".
+* They **go stale** - unless maintained with the code, they become irrelevant.
+* They are **noisy** - comments can clutter your code with multiple unnecessary lines.
+
+If something deserves to live beyond a PR, put it in:
+* An **ADR** (Architectural Design Record).
+* A Design Document.
+* Document it **in code** by using types, doc comments, examples, renaming code blocks into cleaner functions.
+* Add tests to cover and explain the change.
+
+> ### 🚨 If you find a comment, **read it in context**. Does it still make sense? If not, remove or update it, or ask for help. Comments should bother you.
+
+## 8.5 Replace Comments with Code
+
+Instead of long commented blocks, break logic into named helper functions:
+
+#### ❌ Commented code block:
+```rust
+fn save_user(&self) -> Result<(), MyError> {
+    // check if the user is authenticated
+    if self.is_authenticated() {
+        // serialize user data
+        let data = serde_json::to_string(self)?;
+        // write to file
+        std::fs::write(self.path(), data)?;
+    }
+}
+```
+**✅ Extract for clarity**:
+
+```rust
+fn save_auth_user(&self) -> Result<PathBuf, MyError> {
+    if self.is_authenticated() {
+        let path = self.path();
+        let serialized_user = serde_json::to_string(self)?;
+        std::fs::write(path, serialized_user)?;
+        Ok(path)
+    } else {
+        Err(MyError::UserNotAuthenticated)
+    }
+}
+```
+
+## 8.6 `TODO` should become issues
+
+Don't leave `// TODO:` scattered around the codebase with no owner. Instead:
+1. File Github Issue or Jira Ticket. (Prefer github issues on public repositories).
+2. Reference the issue in the code:
+
+```rust
+// TODO(issue #42): Remove workaround after bugfix
+```
+
+This makes `TODO`s trackable, actionable and visible to everyone.
+
+## 8.7 When to use doc comments
+
+Use `///` doc comments to document:
+* All **public functions, structs, traits, enums**.
+* Their purpose, their usage and their behaviors.
+* Anything developers need to understand how to use it correctly.
+* Add context that related to `Errors` and `Panics`.
+* Plenty of examples.
+
+### ✅ Good doc comment:
+
+```rust
+/// Loads [`User`] profile from disk
+/// 
+/// # Error
+/// - Returns [`MyError`] if the file is missing [`MyError::FileNotFound`].
+/// - Returns [`MyError`] if the content is an invalid Json, [`MyError::InvalidJson`].
+fn load_user(path: &Path) -> Result<User, MyError> {...}
+```
+
+**Doc comments can also include examples, links and even tests:**
+
+```rust
+/// Returns the square of the integer part of any number.
+/// Square is limited to `u128`.
+/// 
+/// # Examples
+/// 
+/// ```rust
+/// assert_eq!(square(4.3), 16)
+/// ```
+fn square(x: impl ToInt) -> u128 { ... }
+```
+
+## 8.8 Documentation in Rust: How, When and Why
+
+Rust provides **first-class documentation tooling** via rustdoc, which makes documenting your code a key part of writing idiomatic and maintainable rust. There are doc specific lints to help with documentation, like:
+
+| Lint | Description |
+|-------------- |------------------------------------------- |
+| [missing_docs](https://doc.rust-lang.org/rustdoc/lints.html#missing_docs) | Warns that a public functions, struct, const, enum has missing documentation |
+| [broken_intra_doc_links](https://doc.rust-lang.org/rustdoc/lints.html#broken_intra_doc_links) | Detects if an internal documentation link is broken. Specially useful when things are renamed. |
+| [empty_docs](https://rust-lang.github.io/rust-clippy/master/#empty_docs) | Disallow empty docs - preventing bypass of `missing_docs` |
+| [missing_panics_doc](https://rust-lang.github.io/rust-clippy/master/#missing_panics_doc) | Warns that documentation should have a `# Panics` section if function can panic |
+| [missing_errors_doc](https://rust-lang.github.io/rust-clippy/master/#missing_errors_doc) | Warns that documentation should have a `# Errors` section if function returns a `Result` explaining `Err` conditions |
+| [missing_safety_doc](https://rust-lang.github.io/rust-clippy/master/#missing_safety_doc) | Warns that documentation should have a `# Safety` section if public facing functions have visible unsafe blocks |
+
+
+### Difference between `///` and `//!`
+
+| Style | Used for | Scope |Example |
+|---------- |------------------------------ |------------------------------------------- |---------------------------------------------------------------- |
+| `///` | Line doc comment | Public items like struct, fn, enum, consts | Documenting, giving context and usage to `fn`, `struct`, `enum`, etc |
+| `//!` | Module level doc comment | Modules or entire crates | Explaining crate/module purpose with common use cases and quickstart |
+
+### `///` Item level documentation
+
+Use `///` for functions, structs, traits, enums, const, etc:
+
+```rust
+/// Adds two numbers together.
+///
+/// # Examples
+///
+/// ```
+/// let result = my_crate::add(2, 3);
+/// assert_eq!(result, 5);
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+* ✅ Write clear and descriptive **What it does** and **how to use it**.
+* ✅ Use `# Examples` section to better explain **how to use it**.
+* ✅ Prefer writing examples that can be tested via `cargo test`, even if you have to hide their output with starting `#`:
+```rust
+/// ```
+/// let result = my_crate::add(2, 3);
+/// # assert_eq!(result, 5);
+/// ```
+```
+* ✅ Use `# Panics`, `# Errors` and `# Safety` sections when relevant.
+* Add relevant context to the type.
+
+### `//!` Module/Crate level Documentation
+
+Use `//!` when you want to document the **purpose of a module or a crate**. It is places at the top of a `lib.rs` or `mod.rs` file, for example `engine/mod.rs`:
+```rust
+//! This module implements a custom chess engine.
+//! 
+//! It handles board state, move generation and check detection.
+//! 
+//! # Example
+//! ```
+//! let board = chess::engine::Board::default();
+//! assert!(board.is_valid());
+//! ```
+```
+
+## 8.9 Checklist for Documentation coverage
+
+📦 Crate-Level (lib.rs)
+- [ ] `//!` doc at top explains **what the crate does**, and **what problems it solves**.
+- [ ] Includes crate-level `# Examples` or pointers to modules.
+
+📁 Modules (mod.rs or inline)
+- [ ] `//!` doc explains **what this module is for**, its **exports**, and **invariants**.
+- [ ] Avoid repeating doc comments on re-exported items unless clarification is needed.
+
+🧱 Structs, Enums, Traits
+- `///` doc explains:
+    - [ ] The role this type plays.
+    - [ ] Invariants or expectations.
+    - [ ] Example construction or usage.
+- [ ] Consider using [`#[non_exhaustive]`](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute) if external users may match on it.
+
+🔧 Functions and Methods
+- `///` doc covers:
+    - [ ] What it does.
+    - [ ] Parameters and their meaning.
+    - [ ] Return value behavior.
+    - [ ] Edge cases (`# Panics`, `# Errors`).
+    - [ ] Usage example, `# Examples`.
+
+📑 Traits
+- [ ] Explain the **purpose** of the trait (marker? dynamic dispatch?).
+- [ ] Doc for each method — include **when/why** to implement it.
+- [ ] Document clearly default implemented methods and when to override.
+
+📦 Public Constants
+- [ ] Document what they configure and when you'd want to use them.
+
+### 📌 Best Practices
+* ✅ Use examples generously — they double as test cases.
+* ✅ Prefer clarity over formality — it's for humans, not machines.
+* ✅ Prefer doc comments to explain usage, and leave implementation details to code comments if needed.
+* ✅ Use `cargo doc --open` to check your output often.
+* ✅ Add `#![deny(missing_docs)]` and other relevant doc lints in top-level modules if you want to enforce full doc coverage.

--- a/.cursor/rules/rust-best-practices/references/chapter_09.md
+++ b/.cursor/rules/rust-best-practices/references/chapter_09.md
@@ -1,0 +1,256 @@
+# Chapter 9 - Understanding Pointers
+
+Many higher level languages hide memory management, typically **passing by value** (copy data) or **passing by reference** (reference to shared data) without worrying about allocation, heap, stack, ownership and lifetimes, it is all delegated to the garbage collector or VM. Here is a comparison on this topic between a few languages:
+
+### 📌 Language Comparison 
+
+| Language | Value Types | Reference/Pointer Types | Async Model & Types | Manual Memory |
+|------------ |------------------------------------- |----------------------------------------------------------- |---------------------------------------------------------------------------- |------------------------------ |
+| Python | None | Everything is a reference | async def, await, Task, coroutines and asyncio.Future | ❌ Not Allowed |
+| Javascript | Primitives | Objects | `async/await`, `Promise`, `setTimeout`. single threaded event loop | ❌ Not Allowed |
+| Java | Primitives | Objects | `Future<T>`, threads, Loom (green threads) | ❌ Almost none & not recommended |
+| Go | Values are copied unless using `&T` | Pointers (`*T`, `&T`), escape analysis | goroutines, `channels`, `sync.Mutex`, `context.Context` | ⚠️ Limited |
+| C | Primitives and structs supported | Raw pointers `T*` and `*void` | Threads, event loops (`libuv`, `libevent`) | ✅ Fully |
+| C++ | Primitives and references | Raw `T*` and smart pointers `shared_ptr` and `unique_ptr` | threads, `std::future`, `std::async`, (since c++ 20 `co_await/coroutines`) | ✅ Mostly |
+| Rust | Primitives, Arrays, `impl Copy` | `&T`, `&mut T`, `Box<T>`, `Arc<T>` | `async/await`, `tokio`, `Future`, `JoinHandle`, `Send + Sync` | ✅🔒 Safe and Explicit |
+
+## 9.1 Thread Safety
+
+Rust tracks pointers using `Send` and `Sync` traits:
+- `Send` means data can move across threads.
+- `Sync` means data can be referenced from multiple threads.
+
+> A pointer is thread-safe only if the data behind it is.
+
+| Pointer Type | Short Description | Send + Sync? | Main Use |
+|---------------- |--------------------------------------------------------------------------- |-------------------------------------- |------------ |
+| `&T` | Shared reference | Yes | Shared access |
+| `&mut T` | Exclusive mutable reference | No, not Send | Exclusive mutation |
+| `Box<T>` | Heap-allocated owning pointer | Yes, if T: Send + Sync | Heap allocation |
+| `Rc<T>` | Single-threaded ref counted pointer | No, neither | Multiple owners (single-thread) |
+| `Arc<T>` | Atomic ref counter pointer | Yes | Multiple owners (multi-thread) |
+| `Cell<T>` | Interior mutability for copy types | No, not Sync | Shared mutable, non-threaded |
+| `RefCell<T>` | Interior mutability (dynamic borrow checker) | No, not Sync | Shared mutable, non-threaded |
+| `Mutex<T>` | Thread-safe interior mutability with exclusive access | Yes | Shared mutable, threaded |
+| `RwLock<T>` | Thread-safe shared readonly access OR exclusive mutable access | Yes | Shared mutable, threaded |
+| `OnceCell<T>` | Single-thread one-time initialization container (interior mutability ONCE) | No, not Sync | Simple lazy value initialization |
+| `LazyCell<T>` | A lazy version of `OnceCell<T>` that calls function closure to initialize | No, not Sync | Complex lazy value initialization |
+| `OnceLock<T>` | Thread-safe version of `OnceCell<T>` | Yes | Multi-thread single init |
+| `LazyLock<T>` | Thread-safe version of `LazyCell<T>` | Yes | Multi-thread complex init |
+| `*const T/*mut T` | Raw Pointers | No, user must ensure safety manually | Raw memory / FFI |
+
+## 9.2 When to use pointers:
+
+### `&T` - Shared Borrow:
+
+Probably the most common type in a Rust code base, it is **Safe, with no mutation** and allows **multiple readers**.
+
+```rust
+let data: String = String::from_str("this a string").unwrap();
+
+print_len(&data);
+print_capacity(&data);
+print_bytes(&data);
+
+fn print_len(s: &str) {
+    println!("{}", s.len())
+}
+
+fn print_capacity(s: &String) {
+    println!("{}", s.capacity())
+}
+
+fn print_bytes(s: &String) {
+    println!("{:?}", s.as_bytes())
+}
+```
+### `&mut T` - Exclusive Borrow:
+
+Probably the most common *mutable* type in a Rust code base, it is **Safe, but only allows one mutable borrow at a time**.
+
+```rust
+let mut data: String = String::from_str("this a string").unwrap();
+mark_update(&mut data);
+
+fn mark_update(s: &mut String) {
+    s.push_str("_update");
+}
+```
+
+### [`Box<T>`](https://doc.rust-lang.org/std/boxed/struct.Box.html) - Heap Allocated
+
+Single-owner heap-allocated data, great for recursive types and large structs.
+
+```rust
+pub enum MySubBoxedEnum<T> {
+    Single(T),
+    Double(Box<MySubBoxedEnum<T>>, Box<MySubBoxedEnum<T>>),
+    Multi(Vec<T>), // Note that Vec is already a boxed value
+}
+```
+
+### [`Rc<T>`](https://doc.rust-lang.org/std/rc/struct.Rc.html) - Reference Counter (single-thread)
+
+You need multiple references to data in a single thread. Most common example is linked-list implementation.
+
+### [`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) - Atomic Reference Counter (multi-thread)
+
+You need multiple references to data in multiple threads. Most common use cases is sharing readonly Vec across thread with `Arc<[T]>` and wrapping a `Mutex` so it can be easily shared across threads, `Arc<Mutex<T>>`.
+
+### [`RefCell<T>`](https://doc.rust-lang.org/std/cell/struct.RefCell.html) - Runtime checked interior mutability
+
+Used when you need shared access and the ability to mutate date, borrow rules are enforced at runtime. **It may panic!**.
+
+```rust
+use std::cell::RefCell;
+let x = RefCell::new(42);
+*x.borrow_mut() += 1;
+
+assert_eq!(&*x.borrow(), 42, "Not meaning of life");
+```
+
+Panic example:
+```rust
+use std::cell::RefCell;
+let x = RefCell::new(42);
+
+let borrow = x.borrow();
+
+let mutable = x.borrow_mut();
+```
+
+### [`Cell<T>`](https://doc.rust-lang.org/std/cell/struct.Cell.html) - Copy-only interior mutability
+
+Somewhat the fast and safe version of `RefCell`, but it is limited to types that implement the `Copy` trait:
+
+```rust
+use std::cell::Cell;
+
+struct SomeStruct {
+    regular_field: u8,
+    special_field: Cell<u8>,
+}
+
+let my_struct = SomeStruct {
+    regular_field: 0,
+    special_field: Cell::new(1),
+};
+
+let new_value = 100;
+
+// ERROR: `my_struct` is immutable
+// my_struct.regular_field = new_value;
+
+// WORKS: although `my_struct` is immutable, `special_field` is a `Cell`,
+// which can always be mutated with copy values
+my_struct.special_field.set(new_value);
+assert_eq!(my_struct.special_field.get(), new_value);
+```
+
+### [`Mutex<T>`](https://doc.rust-lang.org/std/sync/struct.Mutex.html) - Thread-safe mutability
+
+An exclusive access pointer that allows a thread to read/write the data contained inside. It is usually wrapped in an `Arc` to allow shared access to the Mutex.
+
+### [`RwLock<T>`](https://doc.rust-lang.org/std/sync/struct.RwLock.html) - Thread-safe mutability
+
+Similar to a `Mutex`, but it allows multiple threads to read it OR a single thread to write. It is usually wrapped in an `Arc` to allow shared access to the RwLock.
+
+
+### [`*const T/*mut T`](https://doc.rust-lang.org/std/primitive.pointer.html) - Raw pointers
+
+Inherently **unsafe** and necessary for FFI. Rust makes their usage explicit to avoid accidental misuse and unwilling manual memory management.
+
+```rust
+let x = 5;
+let ptr = &x as *const i32;
+unsafe {
+    println!("PTR is {}", *ptr)
+}
+```
+
+### [`OnceCell`](https://doc.rust-lang.org/std/cell/struct.OnceCell.html) - Single-thread single initialization container
+
+Most useful when you need to share a configuration between multiple data structures.
+
+```rust
+use std::{cell::OnceCell, rc::Rc};
+
+#[derive(Debug, Default)]
+struct MyStruct {
+    distance: usize,
+    root: Option<Rc<OnceCell<MyStruct>>>, 
+}
+
+fn main() {
+    let root = MyStruct::default();
+    let root_cell = Rc::new(OnceCell::new());
+    if let Err(previous) = root_cell.set(root) {
+        eprintln!("Previous Root {previous:?}");
+    }
+    let child_1 = MyStruct{
+        distance: 1,
+        root: Some(root_cell.clone())
+    };
+
+    let child_2 = MyStruct{
+        distance: 2,
+        root: Some(root_cell.clone())
+    };
+
+
+    println!("Child 1: {child_1:?}");
+    println!("Child 2: {child_2:?}");
+}
+```
+
+### [`LazyCell`](https://doc.rust-lang.org/std/cell/struct.LazyCell.html) - Lazy initialization of `OnceCell`
+
+Useful when the initialized data can be delayed to when it is actually being called.
+
+### [`OnceLock`](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) - thread-safe `OnceCell`
+
+Useful when you need a `static` value.
+
+```rust
+use std::sync::OnceLock;
+
+static CELL: OnceLock<u32> = OnceLock::new();
+
+// `OnceLock` has not been written to yet.
+assert!(CELL.get().is_none());
+
+// Spawn a thread and write to `OnceLock`.
+std::thread::spawn(|| {
+    let value = CELL.get_or_init(|| 12345);
+    assert_eq!(value, &12345);
+})
+.join()
+.unwrap();
+
+// `OnceLock` now contains the value.
+assert_eq!(
+    CELL.get(),
+    Some(&12345),
+);
+```
+
+### [`LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) - thread-safe `LazyCell`
+
+Similar to `OnceLock`, but the static value is a bit more complex to initialize.
+
+```rust
+use std::sync::LazyLock;
+
+static CONFIG: LazyLock<HashMap<&str, T>> = LazyLock::new(|| {
+    let data = read_config();
+    let mut config: HashMap<&str, T> = data.into();
+    config.insert("special_case", T::default());
+    config
+});
+
+let _ = &*CONFIG;
+```
+
+## References
+- [Mara Bos - Rust Atomics and Locks](https://marabos.nl/atomics/)
+- [Semicolon video on pointers](https://www.youtube.com/watch?v=Ag_6Q44PBNs)

--- a/.cursorrules
+++ b/.cursorrules
@@ -7,3 +7,6 @@
 1. **Branch Protection:** NEVER commit code directly to the `master` or `main` branches under any circumstances.
 2. **Feature Branching:** Before making file changes, always checkout a new descriptively named branch: e.g., `git checkout -b <feature-name>`.
 3. **Pull Requests:** Always plan for pushing feature branches to remote via `git push origin <feature-name>` for Pull Requests, honoring the required branch checks.
+
+# Agent Skills
+1. **Rust Best Practices:** Follow the Apollo GraphQL Rust Best Practices when writing or reviewing Rust code. Read `.cursor/rules/rust-best-practices/SKILL.md` and its references before applying any changes to Rust code.

--- a/src/app.rs
+++ b/src/app.rs
@@ -499,7 +499,7 @@ impl App {
         // Calculate Chain Step
         let chain_step = if self.data.len() > 1 {
             let mut strikes: Vec<f64> = self.data.iter().map(|d| d.strike_price).collect();
-            strikes.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            strikes.sort_by(|a, b| a.total_cmp(b));
             strikes.dedup();
 
             let mut min_diff = f64::INFINITY;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use crate::model::OptionData;
+use crate::portfolio::Portfolio;
 use crate::strategy::OptionType;
 use crate::strategy_builder::StrategyBuilder;
-use crate::portfolio::Portfolio;
 use ratatui::widgets::TableState;
 use std::collections::HashSet;
 
@@ -26,12 +26,12 @@ pub struct App {
     pub last_message: String,
     pub table_state: TableState,
     pub show_help: bool,
-    
+
     // New Fields
     pub active_focus: Focus,
     pub strategies: Vec<crate::strategy::Strategy>,
     pub selected_strategy: usize,
-    
+
     // Multi-select
     // Using String for strike to avoid float key issues: format!("{:.2}", strike)
     pub selected_positions: HashSet<(String, OptionType)>,
@@ -39,16 +39,20 @@ pub struct App {
     // Expiry Management
     pub available_expiries: Vec<String>,
     pub current_expiry_index: usize,
-    
+
     // Bid/Ask Depth
     pub market_depth: Option<crate::model::QuoteData>,
 }
 
 impl App {
     pub fn get_selected_instrument_key(&self) -> Option<String> {
-        if self.data.is_empty() { return None; }
-        if self.selected_row >= self.data.len() { return None; }
-        
+        if self.data.is_empty() {
+            return None;
+        }
+        if self.selected_row >= self.data.len() {
+            return None;
+        }
+
         let item = &self.data[self.selected_row];
         match self.selected_column {
             ColumnSelection::Call => item.call_options.as_ref().map(|o| o.instrument_key.clone()),
@@ -58,28 +62,36 @@ impl App {
 
     pub fn new() -> App {
         let all_expiries = vec![
-            "06 Jan 2026", "13 Jan 2026", "20 Jan 2026", "27 Jan 2026",
-            "03 Feb 2026", "24 Feb 2026", "30 Mar 2026", "30 Jun 2026",
-            "29 Sep 2026", "29 Dec 2026"
+            "06 Jan 2026",
+            "13 Jan 2026",
+            "20 Jan 2026",
+            "27 Jan 2026",
+            "03 Feb 2026",
+            "24 Feb 2026",
+            "30 Mar 2026",
+            "30 Jun 2026",
+            "29 Sep 2026",
+            "29 Dec 2026",
         ];
 
         // Filter expiries: Keep only those >= today
-        // Note: In a real app we'd use Local::now().date_naive(), but for this specific request 
+        // Note: In a real app we'd use Local::now().date_naive(), but for this specific request
         // regarding the provided list and "2026", we'll just implement the logic.
         // The user prompt says "once the expiry date is behind the current date, don't show it anymore".
         let today = chrono::Local::now().date_naive();
-        let available_expiries: Vec<String> = all_expiries.into_iter()
+        let available_expiries: Vec<String> = all_expiries
+            .into_iter()
             .filter_map(|date_str| {
                 // Parse date "06 Jan 2026". Format: "%d %b %Y"
                 if let Ok(date) = chrono::NaiveDate::parse_from_str(date_str, "%d %b %Y") {
-                     if date >= today {
-                         return Some(date.format("%Y-%m-%d").to_string());
-                     }
+                    if date >= today {
+                        return Some(date.format("%Y-%m-%d").to_string());
+                    }
                 }
                 None
             })
             .collect();
-        
+
         let initial_expiry_index = 0; // Default to first available (nearest future)
 
         App {
@@ -92,12 +104,12 @@ impl App {
             last_message: String::from("Ready"),
             table_state: TableState::default(),
             show_help: false,
-            
+
             active_focus: Focus::OptionChain,
             strategies: crate::strategy::Strategy::all().to_vec(),
             selected_strategy: 0,
             selected_positions: HashSet::new(),
-            
+
             available_expiries,
             current_expiry_index: initial_expiry_index,
             market_depth: None,
@@ -132,15 +144,17 @@ impl App {
     }
 
     pub fn toggle_selection(&mut self) {
-        if self.data.is_empty() { return; }
-        
+        if self.data.is_empty() {
+            return;
+        }
+
         let item = &self.data[self.selected_row];
         let strike_key = format!("{:.2}", item.strike_price);
         let kind = match self.selected_column {
             ColumnSelection::Call => OptionType::Call,
             ColumnSelection::Put => OptionType::Put,
         };
-        
+
         // Toggle
         let key = (strike_key, kind);
         if self.selected_positions.contains(&key) {
@@ -148,8 +162,12 @@ impl App {
         } else {
             // Only allow selection if a position exists at this strike/kind
             let strike = item.strike_price;
-            let has_position = self.portfolio.positions.iter().any(|p| (p.strike - strike).abs() < 0.01 && p.kind == kind);
-            
+            let has_position = self
+                .portfolio
+                .positions
+                .iter()
+                .any(|p| (p.strike - strike).abs() < 0.01 && p.kind == kind);
+
             if has_position {
                 self.selected_positions.insert(key);
             }
@@ -157,8 +175,10 @@ impl App {
     }
 
     pub fn delete_position(&mut self) {
-        if self.data.is_empty() { return; }
-        
+        if self.data.is_empty() {
+            return;
+        }
+
         let item = &self.data[self.selected_row];
         let strike = item.strike_price;
         let kind = match self.selected_column {
@@ -176,62 +196,88 @@ impl App {
     }
 
     pub fn update_live_prices(&mut self) {
-        if self.data.is_empty() { return; }
+        if self.data.is_empty() {
+            return;
+        }
         self.portfolio.update_prices(&self.data);
     }
 
     pub fn handle_trade_action(&mut self, is_buy: bool) {
-        if self.data.is_empty() { return; }
-        
+        if self.data.is_empty() {
+            return;
+        }
+
         let item = &self.data[self.selected_row];
         let strike = item.strike_price;
         let (kind, price) = match self.selected_column {
-            ColumnSelection::Call => (OptionType::Call, item.call_options.as_ref().map(|o| o.market_data.ltp).unwrap_or(0.0)),
-            ColumnSelection::Put => (OptionType::Put, item.put_options.as_ref().map(|o| o.market_data.ltp).unwrap_or(0.0)),
+            ColumnSelection::Call => (
+                OptionType::Call,
+                item.call_options
+                    .as_ref()
+                    .map(|o| o.market_data.ltp)
+                    .unwrap_or(0.0),
+            ),
+            ColumnSelection::Put => (
+                OptionType::Put,
+                item.put_options
+                    .as_ref()
+                    .map(|o| o.market_data.ltp)
+                    .unwrap_or(0.0),
+            ),
         };
 
         self.last_message = self.portfolio.trade(strike, kind, price, is_buy);
-        
+
         // Cleanup: Remove 0 qty
         // Check for zero qty positions to remove from selection (Portfolio has already removed them from its list)
         // We iterate our selection and check if it still exists in portfolio.
         self.selected_positions.retain(|(s_key, s_kind)| {
-             self.portfolio.positions.iter().any(|p| format!("{:.2}", p.strike) == *s_key && p.kind == *s_kind)
+            self.portfolio
+                .positions
+                .iter()
+                .any(|p| format!("{:.2}", p.strike) == *s_key && p.kind == *s_kind)
         });
     }
     pub fn move_position_row(&mut self, delta: i32) {
-        if self.data.is_empty() { return; }
+        if self.data.is_empty() {
+            return;
+        }
 
         let current_row = self.selected_row;
         let target_row_idx = current_row as i32 + delta;
-        
+
         // 1. Always move cursor if valid
         if target_row_idx >= 0 && target_row_idx < self.data.len() as i32 {
             self.selected_row = target_row_idx as usize;
         } else {
-             // If cursor can't move, we probably shouldn't move positions either?
-             // Or maybe we should? Let's restrict movement to valid data range.
-             return;
+            // If cursor can't move, we probably shouldn't move positions either?
+            // Or maybe we should? Let's restrict movement to valid data range.
+            return;
         }
 
         // 2. Identify positions to move
         // If selection is empty, try to move the one under cursor ONLY if it exists.
         // If selection is NOT empty, move ALL selected positions.
-        
+
         let mut positions_to_move: Vec<usize> = Vec::new(); // Indices in self.positions
-        
+
         if self.selected_positions.is_empty() {
-             // Fallback: Check cursor position
-             let old_item = &self.data[current_row];
-             let old_strike = old_item.strike_price;
-             let kind = match self.selected_column {
-                 ColumnSelection::Call => OptionType::Call,
-                 ColumnSelection::Put => OptionType::Put,
-             };
-             
-             if let Some(pos_idx) = self.portfolio.positions.iter().position(|p| p.strike == old_strike && p.kind == kind) {
-                 positions_to_move.push(pos_idx);
-             }
+            // Fallback: Check cursor position
+            let old_item = &self.data[current_row];
+            let old_strike = old_item.strike_price;
+            let kind = match self.selected_column {
+                ColumnSelection::Call => OptionType::Call,
+                ColumnSelection::Put => OptionType::Put,
+            };
+
+            if let Some(pos_idx) = self
+                .portfolio
+                .positions
+                .iter()
+                .position(|p| p.strike == old_strike && p.kind == kind)
+            {
+                positions_to_move.push(pos_idx);
+            }
         } else {
             // Find all indices that match selected keys
             for (i, p) in self.portfolio.positions.iter().enumerate() {
@@ -241,93 +287,105 @@ impl App {
                 }
             }
         }
-        
-        if positions_to_move.is_empty() { return; }
+
+        if positions_to_move.is_empty() {
+            return;
+        }
 
         // 3. Validate ALL moves first
-        // We need to know "delta indices". 
+        // We need to know "delta indices".
         // Problem: Strikes might not be linear indices if data is not sorted or has gaps (though usually option chain is sorted).
         // Assuming `self.data` is sorted by strike.
         // We find the current index of each position's strike in `self.data`, apply `delta`, and see if it lands on a valid index.
-        
+
         let mut changes: Vec<(usize, f64, f64)> = Vec::new(); // (pos_index, new_strike, new_price)
 
         for &pos_idx in &positions_to_move {
             let pos = &self.portfolio.positions[pos_idx];
-            
+
             // Find current data index for this position's strike
             // Optimization: Assuming sorted, could use binary search, but linear scan is fine for < 200 items.
             // Using a tolerance for float comparison
-            let current_data_idx = self.data.iter().position(|d| (d.strike_price - pos.strike).abs() < 0.01);
-            
+            let current_data_idx = self
+                .data
+                .iter()
+                .position(|d| (d.strike_price - pos.strike).abs() < 0.01);
+
             if let Some(idx) = current_data_idx {
                 let new_data_idx = idx as i32 + delta;
-                
+
                 if new_data_idx >= 0 && new_data_idx < self.data.len() as i32 {
                     let new_data_idx = new_data_idx as usize;
                     let new_item = &self.data[new_data_idx];
                     let new_price = match pos.kind {
-                         OptionType::Call => new_item.call_options.as_ref().map(|o| o.market_data.ltp).unwrap_or(0.0),
-                         OptionType::Put => new_item.put_options.as_ref().map(|o| o.market_data.ltp).unwrap_or(0.0),
+                        OptionType::Call => new_item
+                            .call_options
+                            .as_ref()
+                            .map(|o| o.market_data.ltp)
+                            .unwrap_or(0.0),
+                        OptionType::Put => new_item
+                            .put_options
+                            .as_ref()
+                            .map(|o| o.market_data.ltp)
+                            .unwrap_or(0.0),
                     };
                     changes.push((pos_idx, new_item.strike_price, new_price));
                 } else {
                     // One of the legs would go out of bounds. Abort ALL movement?
                     // Typically yes, to maintain the spread structure.
-                    return; 
+                    return;
                 }
             } else {
                 // Position strike not found in data? Can't move it.
-                return; 
+                return;
             }
         }
-        
+
         // 4. Execute Moves
         // We update input positions.
         // We also need to update `selected_positions` keys if we are in multi-select mode.
-        
+
         let mut temp_selection_updates: Vec<(String, OptionType, String)> = Vec::new(); // (old_key_strike, kind, new_key_strike)
 
         for (pos_idx, new_strike, new_price) in changes {
             // Update position details
             // Note: Merging logic simplified for now; duplicates accepted visually if they occur.
-            
+
             let pos = &mut self.portfolio.positions[pos_idx];
             let old_strike_key = format!("{:.2}", pos.strike);
             let kind = pos.kind;
-            
+
             pos.strike = new_strike;
             pos.entry_price = new_price;
-            
+
             let new_strike_key = format!("{:.2}", new_strike);
             temp_selection_updates.push((old_strike_key, kind, new_strike_key));
         }
 
         // 5. Update Selection Keys
         if !self.selected_positions.is_empty() {
-             for (old_s, kind, new_s) in temp_selection_updates {
-                 let old_key = (old_s, kind);
-                 if self.selected_positions.contains(&old_key) {
-                     self.selected_positions.remove(&old_key);
-                     self.selected_positions.insert((new_s, kind));
-                 }
-             }
+            for (old_s, kind, new_s) in temp_selection_updates {
+                let old_key = (old_s, kind);
+                if self.selected_positions.contains(&old_key) {
+                    self.selected_positions.remove(&old_key);
+                    self.selected_positions.insert((new_s, kind));
+                }
+            }
         }
     }
 
-
-
-
     pub fn apply_strategy(&mut self) {
-        if self.data.is_empty() { return; }
-        
+        if self.data.is_empty() {
+            return;
+        }
+
         let strategy_name = self.strategies[self.selected_strategy];
-        
+
         match StrategyBuilder::build(strategy_name, &self.data) {
             Ok((new_positions, message)) => {
                 self.portfolio.positions = new_positions;
                 self.last_message = message;
-            },
+            }
             Err(e) => {
                 self.last_message = e;
             }
@@ -335,7 +393,9 @@ impl App {
     }
 
     pub fn next_strategy(&mut self) {
-        if self.strategies.is_empty() { return; }
+        if self.strategies.is_empty() {
+            return;
+        }
         if self.selected_strategy < self.strategies.len() - 1 {
             self.selected_strategy += 1;
         } else {
@@ -346,7 +406,9 @@ impl App {
     }
 
     pub fn previous_strategy(&mut self) {
-        if self.strategies.is_empty() { return; }
+        if self.strategies.is_empty() {
+            return;
+        }
         if self.selected_strategy > 0 {
             self.selected_strategy -= 1;
         } else {
@@ -357,47 +419,69 @@ impl App {
     }
 
     pub fn next_expiry(&mut self) -> bool {
-        if self.available_expiries.is_empty() { return false; }
+        if self.available_expiries.is_empty() {
+            return false;
+        }
         if self.current_expiry_index < self.available_expiries.len() - 1 {
             self.current_expiry_index += 1;
             return true; // value changed
         }
         false
     }
-    
+
     pub fn previous_expiry(&mut self) -> bool {
-         if self.available_expiries.is_empty() { return false; }
-         if self.current_expiry_index > 0 {
-             self.current_expiry_index -= 1;
-             return true; // value changed
-         }
-         false
+        if self.available_expiries.is_empty() {
+            return false;
+        }
+        if self.current_expiry_index > 0 {
+            self.current_expiry_index -= 1;
+            return true; // value changed
+        }
+        false
     }
 
     pub fn calculate_strategy_stats(&self) -> crate::strategy::StrategyStats {
-        use chrono::{NaiveDate, Local};
-        
+        use chrono::{Local, NaiveDate};
+
         // Helper to get spot price for Strategy Analysis
-        let spot_price = self.data.first().map(|d| d.underlying_spot_price).unwrap_or(0.0);
-        
+        let spot_price = self
+            .data
+            .first()
+            .map(|d| d.underlying_spot_price)
+            .unwrap_or(0.0);
+
         // Calculate Days to Expiry
         let expiry_str = self.data.first().map(|d| d.expiry.as_str()).unwrap_or("");
-        let days_to_expiry = if let Ok(expiry_date) = NaiveDate::parse_from_str(expiry_str, "%Y-%m-%d") {
-            let today = Local::now().date_naive();
-            (expiry_date - today).num_days().max(1) as f64 // at least 1 day to avoid div/0
-        } else {
-            1.0
-        };
+        let days_to_expiry =
+            if let Ok(expiry_date) = NaiveDate::parse_from_str(expiry_str, "%Y-%m-%d") {
+                let today = Local::now().date_naive();
+                (expiry_date - today).num_days().max(1) as f64 // at least 1 day to avoid div/0
+            } else {
+                1.0
+            };
 
         // Find ATM IV (Average of Call/Put IV at closest strike)
         let atm_iv = if !self.data.is_empty() {
-             let closest = self.data.iter().min_by(|a, b| {
-                (a.strike_price - spot_price).abs().partial_cmp(&(b.strike_price - spot_price).abs()).unwrap_or(std::cmp::Ordering::Equal)
+            let closest = self.data.iter().min_by(|a, b| {
+                (a.strike_price - spot_price)
+                    .abs()
+                    .partial_cmp(&(b.strike_price - spot_price).abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
             });
-            
+
             if let Some(row) = closest {
-                let call_iv = row.call_options.as_ref().and_then(|o| o.option_greeks.as_ref()).map(|g| g.iv).unwrap_or(0.0);
-                let put_iv = row.put_options.as_ref().and_then(|o| o.option_greeks.as_ref()).map(|g| g.iv).unwrap_or(0.0);
+                let call_iv = row
+                    .call_options
+                    .as_ref()
+                    .and_then(|o| o.option_greeks.as_ref())
+                    .map(|g| g.iv)
+                    .unwrap_or(0.0);
+                let put_iv = row
+                    .put_options
+                    .as_ref()
+                    .and_then(|o| o.option_greeks.as_ref())
+                    .map(|g| g.iv)
+                    .unwrap_or(0.0);
                 if call_iv > 0.0 && put_iv > 0.0 {
                     (call_iv + put_iv) / 2.0
                 } else if call_iv > 0.0 {
@@ -417,7 +501,7 @@ impl App {
             let mut strikes: Vec<f64> = self.data.iter().map(|d| d.strike_price).collect();
             strikes.sort_by(|a, b| a.partial_cmp(b).unwrap());
             strikes.dedup();
-            
+
             let mut min_diff = f64::INFINITY;
             for window in strikes.windows(2) {
                 let diff = (window[1] - window[0]).abs();
@@ -425,12 +509,22 @@ impl App {
                     min_diff = diff;
                 }
             }
-            if min_diff != f64::INFINITY { min_diff } else { 50.0 }
+            if min_diff != f64::INFINITY {
+                min_diff
+            } else {
+                50.0
+            }
         } else {
             50.0
         };
 
         use crate::strategy::analyze_strategy;
-        analyze_strategy(&self.portfolio.positions, spot_price, atm_iv, days_to_expiry, chain_step)
+        analyze_strategy(
+            &self.portfolio.positions,
+            spot_price,
+            atm_iv,
+            days_to_expiry,
+            chain_step,
+        )
     }
 }

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -4,7 +4,6 @@ mod tests {
     use crate::model::OptionData;
     use crate::strategy::OptionType;
 
-
     fn create_mock_data() -> Vec<OptionData> {
         let mut data = Vec::new();
         // Strikes: 100, 105, 110, 115, 120
@@ -42,111 +41,135 @@ mod tests {
         assert_eq!(pos.kind, OptionType::Put);
         assert_eq!(pos.qty, 1);
     }
-    
+
     #[test]
     fn test_multi_selection_toggle() {
         let mut app = App::new();
         app.data = create_mock_data(); // 100, 105, 110...
-        
+
         // Select Row 0 (Strike 100), Call Column
         app.selected_row = 0;
         app.selected_column = ColumnSelection::Call;
-        
+
         // 1. Try to toggle on empty position -> Should NOT select
         app.toggle_selection();
-        assert!(app.selected_positions.is_empty(), "Should not select empty position");
-        
+        assert!(
+            app.selected_positions.is_empty(),
+            "Should not select empty position"
+        );
+
         // 2. Add Position
         app.handle_trade_action(true); // Buy Call
-        
+
         // 3. Toggle ON -> Should select
         app.toggle_selection();
-        assert!(app.selected_positions.contains(&("100.00".to_string(), OptionType::Call)));
+        assert!(app
+            .selected_positions
+            .contains(&("100.00".to_string(), OptionType::Call)));
         assert_eq!(app.selected_positions.len(), 1);
-        
+
         // 4. Toggle OFF -> Should remove
         app.toggle_selection();
         assert!(app.selected_positions.is_empty());
-        
+
         // 5. Select again and Delete
         app.toggle_selection();
         assert!(!app.selected_positions.is_empty());
-        
+
         app.delete_position();
         assert!(app.portfolio.positions.is_empty());
-        assert!(app.selected_positions.is_empty(), "Deleting position should remove selection");
+        assert!(
+            app.selected_positions.is_empty(),
+            "Deleting position should remove selection"
+        );
     }
 
     #[test]
     fn test_multi_move() {
         let mut app = App::new();
         app.data = create_mock_data();
-        
+
         // Setup Positions:
         // Position 1: Long Call 100 (Row 0)
         // Position 2: Short Put 110 (Row 2)
-        
+
         // Add Pos 1
         app.selected_row = 0; // 100
         app.selected_column = ColumnSelection::Call;
         app.handle_trade_action(true); // Buy Call
-        
+
         // Add Pos 2
         app.selected_row = 2; // 110
         app.selected_column = ColumnSelection::Put;
         app.handle_trade_action(false); // Sell Put
-        
+
         assert_eq!(app.portfolio.positions.len(), 2);
-        
+
         // Select both positions
         // Select Call 100
         app.selected_row = 0;
         app.selected_column = ColumnSelection::Call;
         app.toggle_selection();
-        
+
         // Select Put 110
         app.selected_row = 2;
         app.selected_column = ColumnSelection::Put;
         app.toggle_selection();
-        
+
         assert_eq!(app.selected_positions.len(), 2);
-        
+
         // Move DOWN (+1 index)
         // 100 -> 105
         // 110 -> 115
         app.move_position_row(1);
-        
+
         // Verify Positions
-        let call_pos = app.portfolio.positions.iter().find(|p| p.kind == OptionType::Call).unwrap();
+        let call_pos = app
+            .portfolio
+            .positions
+            .iter()
+            .find(|p| p.kind == OptionType::Call)
+            .unwrap();
         assert_eq!(call_pos.strike, 105.0);
-        
-        let put_pos = app.portfolio.positions.iter().find(|p| p.kind == OptionType::Put).unwrap();
+
+        let put_pos = app
+            .portfolio
+            .positions
+            .iter()
+            .find(|p| p.kind == OptionType::Put)
+            .unwrap();
         assert_eq!(put_pos.strike, 115.0);
-        
+
         // Verify Selection Keys Updated
-        assert!(app.selected_positions.contains(&("105.00".to_string(), OptionType::Call)));
-        assert!(app.selected_positions.contains(&("115.00".to_string(), OptionType::Put)));
-        assert!(!app.selected_positions.contains(&("100.00".to_string(), OptionType::Call)));
+        assert!(app
+            .selected_positions
+            .contains(&("105.00".to_string(), OptionType::Call)));
+        assert!(app
+            .selected_positions
+            .contains(&("115.00".to_string(), OptionType::Put)));
+        assert!(!app
+            .selected_positions
+            .contains(&("100.00".to_string(), OptionType::Call)));
     }
-    
+
     #[test]
     fn test_multi_move_bounds_check() {
         let mut app = App::new();
         app.data = create_mock_data();
         // Strikes: 100 (idx0), 105 (idx1), 110 (idx2), 115 (idx3), 120 (idx4)
-        
+
         // Position at 120 (idx4). Move Down (+1) should fail.
         app.selected_row = 4;
         app.selected_column = ColumnSelection::Call;
         app.handle_trade_action(true);
         app.toggle_selection();
-        
+
         app.move_position_row(1);
-        
+
         // Should NOT have moved
         let pos = &app.portfolio.positions[0];
         assert_eq!(pos.strike, 120.0);
-        
+
         // Cursor probably shouldn't move either if it was focused there?
         // Logic says `selected_row` updates if cursor is valid.
         // If cursor is at 4, move 1 -> 5 (invalid). Cursor stays at 4.
@@ -154,17 +177,15 @@ mod tests {
     }
     #[test]
     fn test_pop_calculation() {
-        use crate::strategy::{analyze_strategy, Position, OptionType};
-        
-        let positions = vec![
-            Position {
-                strike: 100.0,
-                kind: OptionType::Call,
-                qty: 1,
-                entry_price: 5.0, 
-            }
-        ];
-        
+        use crate::strategy::{analyze_strategy, OptionType, Position};
+
+        let positions = vec![Position {
+            strike: 100.0,
+            kind: OptionType::Call,
+            qty: 1,
+            entry_price: 5.0,
+        }];
+
         // Spot 100, Strike 100. Breakeven 105.
         // IV 20%, Time 1 Year.
         // PoP should be Prob(Spot > 105).
@@ -174,9 +195,9 @@ mod tests {
         // Prob(x < Z) = CDF(0.3439) ~= 0.63.
         // Prob(x > Z) = 1 - 0.63 = 0.37.
         // So PoP should be around 37%.
-        
+
         let stats = analyze_strategy(&positions, 100.0, 20.0, 365.0, 5.0);
-        
+
         println!("PoP: {}", stats.pop);
         // Using broad range to allow for slight drift/calc diffs
         assert!(stats.pop > 0.30 && stats.pop < 0.45);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,14 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 mod app;
-mod model;
-mod ui;
-mod strategy;
-mod strategy_builder;
-mod portfolio;
-mod tui;
 #[cfg(test)]
 mod app_tests;
+mod model;
+mod portfolio;
+mod strategy;
+mod strategy_builder;
+mod tui;
+mod ui;
 
 use app::App;
 use model::ApiResponse;
@@ -28,26 +28,31 @@ async fn main() -> Result<()> {
     // 2. Setup App
     let mut app = App::new();
     // Default to first available expiry, or a fallback if empty
-    let initial_expiry = app.available_expiries.first().cloned().unwrap_or_else(|| String::from("29 Jan 2026"));
-    
+    let initial_expiry = app
+        .available_expiries
+        .first()
+        .cloned()
+        .unwrap_or_else(|| String::from("29 Jan 2026"));
+
     // Create channel for expiry updates
     let (expiry_tx, expiry_rx) = tokio::sync::watch::channel(initial_expiry.clone());
 
     // 3. Get Access Token (TUI Mode)
     let validation_url = format!(
-        "{}?instrument_key={}&expiry_date={}", 
-        UPSTOX_API_BASE, 
-        urlencoding::encode(INSTRUMENT_KEY), 
+        "{}?instrument_key={}&expiry_date={}",
+        UPSTOX_API_BASE,
+        urlencoding::encode(INSTRUMENT_KEY),
         initial_expiry
     );
-    
+
     // Check if we have a locally saved valid token first
-    let setup_result = if let Some(token) = ui::setup::load_and_validate_token(&validation_url).await {
-        ui::setup::SetupResult::Token(token)
-    } else {
-        // Fall back to TUI if no valid token is found
-        ui::setup::run_setup_tui(&mut tui.terminal, &validation_url).await?
-    };
+    let setup_result =
+        if let Some(token) = ui::setup::load_and_validate_token(&validation_url).await {
+            ui::setup::SetupResult::Token(token)
+        } else {
+            // Fall back to TUI if no valid token is found
+            ui::setup::run_setup_tui(&mut tui.terminal, &validation_url).await?
+        };
 
     // 4. Setup Data Channel
     // We now use TuiMessage to support both options data and quotes
@@ -60,20 +65,20 @@ async fn main() -> Result<()> {
         ui::setup::SetupResult::Token(token) => {
             let token_clone = token.clone();
             let mut expiry_rx_clone = expiry_rx.clone();
-            let main_tx = tx.clone(); 
-            
+            let main_tx = tx.clone();
+
             // TASK A: Option Chain Polling
             tokio::spawn(async move {
                 let client = reqwest::Client::new();
-                
+
                 loop {
                     // Get current expiry from watch channel
                     let current_expiry = expiry_rx_clone.borrow_and_update().clone();
 
                     let url = format!(
-                        "{}?instrument_key={}&expiry_date={}", 
-                        UPSTOX_API_BASE, 
-                        urlencoding::encode(INSTRUMENT_KEY), 
+                        "{}?instrument_key={}&expiry_date={}",
+                        UPSTOX_API_BASE,
+                        urlencoding::encode(INSTRUMENT_KEY),
                         current_expiry
                     );
 
@@ -84,17 +89,19 @@ async fn main() -> Result<()> {
                         .header("Authorization", format!("Bearer {}", token_clone))
                         .send()
                         .await;
-        
+
                     match res {
                         Ok(response) => {
                             if let Ok(api_response) = response.json::<ApiResponse>().await {
                                 if !api_response.data.is_empty() {
-                                    let _ = main_tx.send(tui::TuiMessage::OptionChain(api_response.data)).await;
+                                    let _ = main_tx
+                                        .send(tui::TuiMessage::OptionChain(api_response.data))
+                                        .await;
                                 }
                             }
                         }
                         Err(e) => {
-                             eprintln!("Error fetching data: {}", e);
+                            eprintln!("Error fetching data: {}", e);
                         }
                     }
                     tokio::time::sleep(Duration::from_secs(1)).await;
@@ -104,7 +111,7 @@ async fn main() -> Result<()> {
             // TASK B: Quote Fetcher (Auto-Refresh)
             let token_quote = token.clone();
             let quote_result_tx = tx.clone();
-            
+
             tokio::spawn(async move {
                 let client = reqwest::Client::new();
                 let mut current_key: Option<String> = None;
@@ -127,7 +134,7 @@ async fn main() -> Result<()> {
                                             .header("Content-Type", "application/json")
                                             .header("Accept", "application/json")
                                             .header("Authorization", format!("Bearer {}", token_quote))
-                                            .send().await 
+                                            .send().await
                                         {
                                             if let Ok(quote_res) = response.json::<model::MarketQuoteResponse>().await {
                                                 if let Some(data) = quote_res.data.values().next() {
@@ -150,7 +157,7 @@ async fn main() -> Result<()> {
                                     .header("Content-Type", "application/json")
                                     .header("Accept", "application/json")
                                     .header("Authorization", format!("Bearer {}", token_quote))
-                                    .send().await 
+                                    .send().await
                                 {
                                     if let Ok(quote_res) = response.json::<model::MarketQuoteResponse>().await {
                                         if let Some(data) = quote_res.data.values().next() {
@@ -163,7 +170,7 @@ async fn main() -> Result<()> {
                     }
                 }
             });
-        },
+        }
         ui::setup::SetupResult::Demo => {
             // Demo loops
             let demo_tx = tx.clone();
@@ -171,7 +178,7 @@ async fn main() -> Result<()> {
                 // Send initial data
                 let dummy_data = ApiResponse::generate_dummy_data();
                 let _ = demo_tx.send(tui::TuiMessage::OptionChain(dummy_data)).await;
-                
+
                 loop {
                     tokio::time::sleep(Duration::from_secs(2)).await;
                     let dummy_data = ApiResponse::generate_dummy_data();
@@ -184,7 +191,7 @@ async fn main() -> Result<()> {
             tokio::spawn(async move {
                 let mut current_key: Option<String> = None;
                 let mut interval = tokio::time::interval(Duration::from_secs(1));
-                
+
                 loop {
                     tokio::select! {
                         res = quote_request_rx.recv() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
             });
 
             // TASK B: Quote Fetcher (Auto-Refresh)
-            let token_quote = token.clone();
+            let token_quote = token;
             let quote_result_tx = tx.clone();
 
             tokio::spawn(async move {

--- a/src/model.rs
+++ b/src/model.rs
@@ -96,7 +96,10 @@ impl ApiResponse {
     pub fn generate_dummy_data() -> Vec<OptionData> {
         let json_data = include_str!("demo_data.json");
         let response: ApiResponse =
-            serde_json::from_str(json_data).expect("Failed to parse demo data");
+            serde_json::from_str(json_data).unwrap_or_else(|_| ApiResponse {
+                status: "success".to_string(),
+                data: Vec::new(),
+            });
         response.data
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -95,7 +95,8 @@ pub struct Ohlc {
 impl ApiResponse {
     pub fn generate_dummy_data() -> Vec<OptionData> {
         let json_data = include_str!("demo_data.json");
-        let response: ApiResponse = serde_json::from_str(json_data).expect("Failed to parse demo data");
+        let response: ApiResponse =
+            serde_json::from_str(json_data).expect("Failed to parse demo data");
         response.data
     }
 }
@@ -109,21 +110,66 @@ impl QuoteData {
             last_price: 100.0,
             depth: Depth {
                 buy: vec![
-                    DepthEntry { quantity: 100, price: 99.5, orders: 5 },
-                    DepthEntry { quantity: 200, price: 99.0, orders: 3 },
-                    DepthEntry { quantity: 150, price: 98.5, orders: 2 },
-                    DepthEntry { quantity: 50, price: 98.0, orders: 1 },
-                    DepthEntry { quantity: 20, price: 97.5, orders: 1 },
+                    DepthEntry {
+                        quantity: 100,
+                        price: 99.5,
+                        orders: 5,
+                    },
+                    DepthEntry {
+                        quantity: 200,
+                        price: 99.0,
+                        orders: 3,
+                    },
+                    DepthEntry {
+                        quantity: 150,
+                        price: 98.5,
+                        orders: 2,
+                    },
+                    DepthEntry {
+                        quantity: 50,
+                        price: 98.0,
+                        orders: 1,
+                    },
+                    DepthEntry {
+                        quantity: 20,
+                        price: 97.5,
+                        orders: 1,
+                    },
                 ],
                 sell: vec![
-                    DepthEntry { quantity: 80, price: 100.5, orders: 4 },
-                    DepthEntry { quantity: 120, price: 101.0, orders: 6 },
-                    DepthEntry { quantity: 90, price: 101.5, orders: 2 },
-                    DepthEntry { quantity: 40, price: 102.0, orders: 1 },
-                    DepthEntry { quantity: 10, price: 102.5, orders: 1 },
-                ]
+                    DepthEntry {
+                        quantity: 80,
+                        price: 100.5,
+                        orders: 4,
+                    },
+                    DepthEntry {
+                        quantity: 120,
+                        price: 101.0,
+                        orders: 6,
+                    },
+                    DepthEntry {
+                        quantity: 90,
+                        price: 101.5,
+                        orders: 2,
+                    },
+                    DepthEntry {
+                        quantity: 40,
+                        price: 102.0,
+                        orders: 1,
+                    },
+                    DepthEntry {
+                        quantity: 10,
+                        price: 102.5,
+                        orders: 1,
+                    },
+                ],
             },
-            ohlc: Ohlc { open: 100.0, high: 102.0, low: 98.0, close: 100.0 },
+            ohlc: Ohlc {
+                open: 100.0,
+                high: 102.0,
+                low: 98.0,
+                close: 100.0,
+            },
             volume: 1000,
             oi: 50000.0,
         }
@@ -198,6 +244,13 @@ mod tests {
         }
         "#;
         let response: ApiResponse = serde_json::from_str(json_data).expect("Failed to deserialize");
-        assert_eq!(response.data[0].call_options.as_ref().unwrap().instrument_key, "NSE_FO|51059");
+        assert_eq!(
+            response.data[0]
+                .call_options
+                .as_ref()
+                .unwrap()
+                .instrument_key,
+            "NSE_FO|51059"
+        );
     }
 }

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -1,5 +1,5 @@
-use crate::strategy::{Position, OptionType};
 use crate::model::OptionData;
+use crate::strategy::{OptionType, Position};
 
 pub struct Portfolio {
     pub positions: Vec<Position>,
@@ -19,12 +19,16 @@ impl Portfolio {
             OptionType::Put => "PE",
         };
 
-        if let Some(pos) = self.positions.iter_mut().find(|p| (p.strike - strike).abs() < 0.01 && p.kind == kind) {
-             // Flip logic or increment
-             if is_buy {
+        if let Some(pos) = self
+            .positions
+            .iter_mut()
+            .find(|p| (p.strike - strike).abs() < 0.01 && p.kind == kind)
+        {
+            // Flip logic or increment
+            if is_buy {
                 if pos.qty < 0 {
-                     pos.qty = 1;
-                     pos.entry_price = price;
+                    pos.qty = 1;
+                    pos.entry_price = price;
                 } else {
                     pos.qty += 1;
                     let old_total = pos.entry_price * (pos.qty - 1) as f64;
@@ -56,13 +60,17 @@ impl Portfolio {
     }
 
     pub fn remove(&mut self, strike: f64, kind: OptionType) {
-        self.positions.retain(|p| !((p.strike - strike).abs() < 0.01 && p.kind == kind));
+        self.positions
+            .retain(|p| !((p.strike - strike).abs() < 0.01 && p.kind == kind));
     }
 
     pub fn update_prices(&mut self, data: &[OptionData]) {
         for pos in &mut self.positions {
             // Find current market price for this position
-            if let Some(market_row) = data.iter().find(|d| (d.strike_price - pos.strike).abs() < 0.1) {
+            if let Some(market_row) = data
+                .iter()
+                .find(|d| (d.strike_price - pos.strike).abs() < 0.1)
+            {
                 let current_ltp = match pos.kind {
                     OptionType::Call => market_row.call_options.as_ref().map(|o| o.market_data.ltp),
                     OptionType::Put => market_row.put_options.as_ref().map(|o| o.market_data.ltp),
@@ -75,5 +83,3 @@ impl Portfolio {
         }
     }
 }
-
-

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -261,7 +261,7 @@ pub fn analyze_strategy(
         let mut sorted_points = breakevens.clone();
         sorted_points.push(0.0); // Start
         sorted_points.push(f64::INFINITY); // End
-        sorted_points.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        sorted_points.sort_by(|a, b| a.total_cmp(b));
         sorted_points.dedup();
 
         for window in sorted_points.windows(2) {

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -5,7 +5,7 @@ pub const LOT_SIZE: f64 = 65.0;
 const GRAPH_STEPS: usize = 200;
 const IV_WINDOW_SIGMA: f64 = 1.5; // Number of SDs for graph range
 const DEFAULT_VOLATILITY: f64 = 0.05; // Fallback only if IV is 0
-const UNLIMITED_SLOPE_THRESHOLD: f64 = 1e-4; 
+const UNLIMITED_SLOPE_THRESHOLD: f64 = 1e-4;
 const RISK_FREE_RATE: f64 = 0.0; // Current assumption
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
@@ -91,7 +91,7 @@ impl Position {
             OptionType::Call => (spot_at_expiry - self.strike).max(0.0),
             OptionType::Put => (self.strike - spot_at_expiry).max(0.0),
         };
-        
+
         // Note: entry_price is per unit.
         // If Buy: Pay entry_price. PnL = (Intrinsic - Entry)
         // If Sell: Receive entry_price. PnL = (Entry - Intrinsic) = -(Intrinsic - Entry)
@@ -117,8 +117,8 @@ fn std_normal_cdf(x: f64) -> f64 {
 
     let abs_x = x.abs();
     let t = 1.0 / (1.0 + p * abs_x);
-    let val = 1.0 - c2 * (-x * x / 2.0).exp() *
-        (t * (b1 + t * (b2 + t * (b3 + t * (b4 + t * b5)))));
+    let val =
+        1.0 - c2 * (-x * x / 2.0).exp() * (t * (b1 + t * (b2 + t * (b3 + t * (b4 + t * b5)))));
 
     if x < 0.0 {
         1.0 - val
@@ -127,13 +127,12 @@ fn std_normal_cdf(x: f64) -> f64 {
     }
 }
 
-
 pub fn analyze_strategy(
-    positions: &[Position], 
-    current_spot: f64, 
-    iv: f64, 
+    positions: &[Position],
+    current_spot: f64,
+    iv: f64,
     days_to_expiry: f64,
-    chain_step: f64
+    chain_step: f64,
 ) -> StrategyStats {
     if positions.is_empty() {
         return StrategyStats::default();
@@ -147,53 +146,61 @@ pub fn analyze_strategy(
         } else {
             current_spot * DEFAULT_VOLATILITY
         };
-        (current_spot - volatility_range, current_spot + volatility_range)
+        (
+            current_spot - volatility_range,
+            current_spot + volatility_range,
+        )
     } else {
         // Structure-based Range (N + 3 strikes)
         let strikes: Vec<f64> = positions.iter().map(|p| p.strike).collect();
         let min_strike = strikes.iter().cloned().fold(f64::INFINITY, f64::min);
         let max_strike = strikes.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-        
+
         // Use supplied chain step for padding (N + 3 strikes)
         let padding = 3.0 * chain_step;
-        
+
         // Ensure Spot is included.
         // Bounds: [min_strike - pad, max_strike + pad] expanded to include spot if needed.
         let l = (min_strike - padding).min(current_spot - chain_step);
         let u = (max_strike + padding).max(current_spot + chain_step);
-        
+
         (l, u)
     };
 
     let step_size = (upper_bound - lower_bound) / GRAPH_STEPS as f64;
 
     let mut max_profit = f64::NEG_INFINITY;
-    let mut max_loss = f64::INFINITY; 
+    let mut max_loss = f64::INFINITY;
     let mut breakevens = Vec::new();
     let mut points = Vec::new();
 
     let mut prev_pnl = calculate_net_payoff(positions, lower_bound);
-    
+
     // 1. Calculate Graph Points & Range Extrema & Breakevens
     for i in 0..=GRAPH_STEPS {
         let spot = lower_bound + i as f64 * step_size;
         let pnl = calculate_net_payoff(positions, spot);
 
-        if pnl > max_profit { max_profit = pnl; }
-        if pnl < max_loss { max_loss = pnl; }
+        if pnl > max_profit {
+            max_profit = pnl;
+        }
+        if pnl < max_loss {
+            max_loss = pnl;
+        }
 
         // Breakeven crossing
         if (prev_pnl < 0.0 && pnl >= 0.0) || (prev_pnl > 0.0 && pnl <= 0.0) {
             let prev_spot = spot - step_size;
             // Linear iterpolation for precise root
             if (pnl - prev_pnl).abs() > 1e-9 {
-                let zero_spot = prev_spot + (0.0 - prev_pnl) * (spot - prev_spot) / (pnl - prev_pnl);
+                let zero_spot =
+                    prev_spot + (0.0 - prev_pnl) * (spot - prev_spot) / (pnl - prev_pnl);
                 breakevens.push(zero_spot);
             } else {
                 breakevens.push(spot);
             }
         }
-        
+
         points.push((spot, pnl));
         prev_pnl = pnl;
     }
@@ -208,15 +215,23 @@ pub fn analyze_strategy(
     let mut max_profit_unlimited = false;
     let mut max_loss_unlimited = false;
 
-    if slope_high > UNLIMITED_SLOPE_THRESHOLD { max_profit_unlimited = true; }
-    if slope_high < -UNLIMITED_SLOPE_THRESHOLD { max_loss_unlimited = true; }
-    
+    if slope_high > UNLIMITED_SLOPE_THRESHOLD {
+        max_profit_unlimited = true;
+    }
+    if slope_high < -UNLIMITED_SLOPE_THRESHOLD {
+        max_loss_unlimited = true;
+    }
+
     let pnl_zero = calculate_net_payoff(positions, 0.0);
-    
+
     let candidates = vec![pnl_zero, pnl_high];
     for val in candidates {
-        if !max_profit_unlimited && val > max_profit { max_profit = val; }
-        if !max_loss_unlimited && val < max_loss { max_loss = val; }
+        if !max_profit_unlimited && val > max_profit {
+            max_profit = val;
+        }
+        if !max_loss_unlimited && val < max_loss {
+            max_loss = val;
+        }
     }
 
     // 4. Calculate PoP
@@ -225,32 +240,34 @@ pub fn analyze_strategy(
         let t_years = days_to_expiry / 365.0;
         let sigma = iv / 100.0;
         let sigma_sqrt_t = sigma * t_years.sqrt();
-        let drift = (RISK_FREE_RATE - 0.5 * sigma * sigma) * t_years; 
-        
+        let drift = (RISK_FREE_RATE - 0.5 * sigma * sigma) * t_years;
+
         // Helper to get prob < X (Prob Price ends below X)
         // ln(ST/S0) ~ N(drift, vol)
         // ln(ST) - ln(S0) < Z
         // ln(X/S0) < Z
         let prob_below = |price: f64| -> f64 {
-            if price <= 0.0 { return 0.0; }
-            let d2 = ( (price / current_spot).ln() - drift ) / sigma_sqrt_t;
+            if price <= 0.0 {
+                return 0.0;
+            }
+            let d2 = ((price / current_spot).ln() - drift) / sigma_sqrt_t;
             std_normal_cdf(d2)
         };
 
         // We identify profitable intervals.
         // Breakevens divide the line into segments.
         // We test a point in each segment.
-        
+
         let mut sorted_points = breakevens.clone();
         sorted_points.push(0.0); // Start
         sorted_points.push(f64::INFINITY); // End
         sorted_points.sort_by(|a, b| a.partial_cmp(b).unwrap());
         sorted_points.dedup();
-        
+
         for window in sorted_points.windows(2) {
             let start = window[0];
             let end = window[1];
-            
+
             // Test mid point
             let test_point = if end == f64::INFINITY {
                 start + 1.0 // just above start
@@ -259,10 +276,14 @@ pub fn analyze_strategy(
             } else {
                 (start + end) / 2.0
             };
-            
+
             if calculate_net_payoff(positions, test_point) > 0.0 {
                 // This segment is profitable. Add probability mass.
-                let p_end = if end == f64::INFINITY { 1.0 } else { prob_below(end) };
+                let p_end = if end == f64::INFINITY {
+                    1.0
+                } else {
+                    prob_below(end)
+                };
                 let p_start = prob_below(start);
                 pop += p_end - p_start;
             }

--- a/src/strategy_builder.rs
+++ b/src/strategy_builder.rs
@@ -1,5 +1,5 @@
 use crate::model::OptionData;
-use crate::strategy::{Position, OptionType, Strategy};
+use crate::strategy::{OptionType, Position, Strategy};
 use std::cmp::Ordering;
 
 // Constants for Strategy Building
@@ -14,16 +14,55 @@ pub struct StrategyBuilder;
 
 impl StrategyBuilder {
     /// Builds a strategy based on the enum and option data.
-    pub fn build(strategy: Strategy, data: &[OptionData]) -> Result<(Vec<Position>, String), String> {
+    pub fn build(
+        strategy: Strategy,
+        data: &[OptionData],
+    ) -> Result<(Vec<Position>, String), String> {
         match strategy {
-            Strategy::CallCreditSpread => Self::build_vertical_spread(data, OptionType::Call, false, DELTA_OTM_30, STRIKE_WIDTH_NARROW, "CCS"),
-            Strategy::PutCreditSpread => Self::build_vertical_spread(data, OptionType::Put, false, -DELTA_OTM_30, STRIKE_WIDTH_NARROW, "PCS"),
-            Strategy::CallDebitSpread => Self::build_vertical_spread(data, OptionType::Call, true, DELTA_ATM, STRIKE_WIDTH_NARROW, "CDS"),
-            Strategy::PutDebitSpread => Self::build_vertical_spread(data, OptionType::Put, true, -DELTA_ATM, STRIKE_WIDTH_NARROW, "PDS"),
-            Strategy::LongCall => Self::build_single_option(data, OptionType::Call, true, DELTA_ATM, "Long Call"),
-            Strategy::LongPut => Self::build_single_option(data, OptionType::Put, true, -DELTA_ATM, "Long Put"),
-            Strategy::ShortCall => Self::build_single_option(data, OptionType::Call, false, DELTA_OTM_30, "Short Call"),
-            Strategy::ShortPut => Self::build_single_option(data, OptionType::Put, false, -DELTA_OTM_30, "Short Put"),
+            Strategy::CallCreditSpread => Self::build_vertical_spread(
+                data,
+                OptionType::Call,
+                false,
+                DELTA_OTM_30,
+                STRIKE_WIDTH_NARROW,
+                "CCS",
+            ),
+            Strategy::PutCreditSpread => Self::build_vertical_spread(
+                data,
+                OptionType::Put,
+                false,
+                -DELTA_OTM_30,
+                STRIKE_WIDTH_NARROW,
+                "PCS",
+            ),
+            Strategy::CallDebitSpread => Self::build_vertical_spread(
+                data,
+                OptionType::Call,
+                true,
+                DELTA_ATM,
+                STRIKE_WIDTH_NARROW,
+                "CDS",
+            ),
+            Strategy::PutDebitSpread => Self::build_vertical_spread(
+                data,
+                OptionType::Put,
+                true,
+                -DELTA_ATM,
+                STRIKE_WIDTH_NARROW,
+                "PDS",
+            ),
+            Strategy::LongCall => {
+                Self::build_single_option(data, OptionType::Call, true, DELTA_ATM, "Long Call")
+            }
+            Strategy::LongPut => {
+                Self::build_single_option(data, OptionType::Put, true, -DELTA_ATM, "Long Put")
+            }
+            Strategy::ShortCall => {
+                Self::build_single_option(data, OptionType::Call, false, DELTA_OTM_30, "Short Call")
+            }
+            Strategy::ShortPut => {
+                Self::build_single_option(data, OptionType::Put, false, -DELTA_OTM_30, "Short Put")
+            }
             Strategy::ShortStraddle => Self::build_straddle(data, "Short Straddle"),
             Strategy::ShortStrangle => Self::build_strangle(data, DELTA_OTM_16, "Short Strangle"),
             Strategy::IronButterfly => Self::build_iron_butterfly(data, "Iron Fly"),
@@ -34,12 +73,12 @@ impl StrategyBuilder {
     // --- Strategy Implementations ---
 
     fn build_vertical_spread(
-        data: &[OptionData], 
-        kind: OptionType, 
-        is_debit: bool, 
-        anchor_delta: f64, 
-        width: f64, 
-        label: &str
+        data: &[OptionData],
+        kind: OptionType,
+        is_debit: bool,
+        anchor_delta: f64,
+        width: f64,
+        label: &str,
     ) -> Result<(Vec<Position>, String), String> {
         let anchor_idx = if kind == OptionType::Call {
             Self::find_call_by_delta(data, anchor_delta)
@@ -53,39 +92,57 @@ impl StrategyBuilder {
             let anchor_price = Self::get_price(anchor_item, kind)?;
 
             // Determine target strike for the second leg
-            
+
             let width_sign = match kind {
-                OptionType::Call => 1.0, 
+                OptionType::Call => 1.0,
                 OptionType::Put => -1.0,
             };
-            
+
             let target_strike = anchor_strike + (width * width_sign);
-            
-            let leg2_item = data.iter().find(|d| (d.strike_price - target_strike).abs() < 1.0);
-            
+
+            let leg2_item = data
+                .iter()
+                .find(|d| (d.strike_price - target_strike).abs() < 1.0);
+
             if let Some(leg2) = leg2_item {
                 let leg2_price = Self::get_price(leg2, kind)?;
-                
+
                 let (qty1, qty2) = if is_debit { (1, -1) } else { (-1, 1) };
-                
-                let p1 = Position { strike: anchor_strike, kind, qty: qty1, entry_price: anchor_price };
-                let p2 = Position { strike: target_strike, kind, qty: qty2, entry_price: leg2_price };
-                
-                Ok((vec![p1, p2], format!("Applied: {} ({}/{})", label, anchor_strike, target_strike)))
+
+                let p1 = Position {
+                    strike: anchor_strike,
+                    kind,
+                    qty: qty1,
+                    entry_price: anchor_price,
+                };
+                let p2 = Position {
+                    strike: target_strike,
+                    kind,
+                    qty: qty2,
+                    entry_price: leg2_price,
+                };
+
+                Ok((
+                    vec![p1, p2],
+                    format!("Applied: {} ({}/{})", label, anchor_strike, target_strike),
+                ))
             } else {
                 Err(format!("Error: Wing strike {} not found", target_strike))
             }
         } else {
-            Err(format!("Error: Anchor leg (Delta ~{}) not found", anchor_delta))
+            Err(format!(
+                "Error: Anchor leg (Delta ~{}) not found",
+                anchor_delta
+            ))
         }
     }
 
     fn build_single_option(
-        data: &[OptionData], 
-        kind: OptionType, 
-        is_buy: bool, 
-        delta: f64, 
-        label: &str
+        data: &[OptionData],
+        kind: OptionType,
+        is_buy: bool,
+        delta: f64,
+        label: &str,
     ) -> Result<(Vec<Position>, String), String> {
         let idx_opt = if kind == OptionType::Call {
             Self::find_call_by_delta(data, delta)
@@ -97,9 +154,17 @@ impl StrategyBuilder {
             let item = &data[idx];
             let price = Self::get_price(item, kind)?;
             let qty = if is_buy { 1 } else { -1 };
-            
-            let pos = Position { strike: item.strike_price, kind, qty, entry_price: price };
-            Ok((vec![pos], format!("Applied: {} ({})", label, item.strike_price)))
+
+            let pos = Position {
+                strike: item.strike_price,
+                kind,
+                qty,
+                entry_price: price,
+            };
+            Ok((
+                vec![pos],
+                format!("Applied: {} ({})", label, item.strike_price),
+            ))
         } else {
             Err(format!("Error: Option (Delta ~{}) not found", delta))
         }
@@ -107,72 +172,129 @@ impl StrategyBuilder {
 
     fn build_straddle(data: &[OptionData], label: &str) -> Result<(Vec<Position>, String), String> {
         // ATM Call & Put
-        let c_idx = Self::find_call_by_delta(data, DELTA_ATM); 
-        
+        let c_idx = Self::find_call_by_delta(data, DELTA_ATM);
+
         if let Some(idx) = c_idx {
             let item = &data[idx];
             let strike = item.strike_price;
             let call_price = Self::get_price(item, OptionType::Call)?;
-            let put_price = Self::get_price(item, OptionType::Put)?; 
-            
+            let put_price = Self::get_price(item, OptionType::Put)?;
+
             // Safer:
             if item.put_options.is_none() {
                 return Err(format!("Error: Put data missing for ATM strike {}", strike));
             }
 
-            let p1 = Position { strike, kind: OptionType::Call, qty: -1, entry_price: call_price };
-            let p2 = Position { strike, kind: OptionType::Put, qty: -1, entry_price: put_price };
-            
+            let p1 = Position {
+                strike,
+                kind: OptionType::Call,
+                qty: -1,
+                entry_price: call_price,
+            };
+            let p2 = Position {
+                strike,
+                kind: OptionType::Put,
+                qty: -1,
+                entry_price: put_price,
+            };
+
             Ok((vec![p1, p2], format!("Applied: {} ({})", label, strike)))
         } else {
             Err("Error: ATM Strike not found".to_string())
         }
     }
 
-    fn build_strangle(data: &[OptionData], delta: f64, label: &str) -> Result<(Vec<Position>, String), String> {
+    fn build_strangle(
+        data: &[OptionData],
+        delta: f64,
+        label: &str,
+    ) -> Result<(Vec<Position>, String), String> {
         let c_idx = Self::find_call_by_delta(data, delta);
         let p_idx = Self::find_put_by_delta(data, -delta);
 
         if let (Some(ci), Some(pi)) = (c_idx, p_idx) {
             let c_item = &data[ci];
             let p_item = &data[pi];
-            
+
             let c_price = Self::get_price(c_item, OptionType::Call)?;
             let p_price = Self::get_price(p_item, OptionType::Put)?;
 
-            let p1 = Position { strike: c_item.strike_price, kind: OptionType::Call, qty: -1, entry_price: c_price };
-            let p2 = Position { strike: p_item.strike_price, kind: OptionType::Put, qty: -1, entry_price: p_price };
-            
-            Ok((vec![p1, p2], format!("Applied: {} ({}/{})", label, p_item.strike_price, c_item.strike_price)))
+            let p1 = Position {
+                strike: c_item.strike_price,
+                kind: OptionType::Call,
+                qty: -1,
+                entry_price: c_price,
+            };
+            let p2 = Position {
+                strike: p_item.strike_price,
+                kind: OptionType::Put,
+                qty: -1,
+                entry_price: p_price,
+            };
+
+            Ok((
+                vec![p1, p2],
+                format!(
+                    "Applied: {} ({}/{})",
+                    label, p_item.strike_price, c_item.strike_price
+                ),
+            ))
         } else {
             Err(format!("Error: Strangle legs (Delta ~{}) not found", delta))
         }
     }
 
-    fn build_iron_butterfly(data: &[OptionData], label: &str) -> Result<(Vec<Position>, String), String> {
+    fn build_iron_butterfly(
+        data: &[OptionData],
+        label: &str,
+    ) -> Result<(Vec<Position>, String), String> {
         let center_idx = Self::find_call_by_delta(data, DELTA_ATM);
         if let Some(idx) = center_idx {
             let center_item = &data[idx];
             let center_strike = center_item.strike_price;
-            
+
             let u_strike = center_strike + STRIKE_WIDTH_WIDE;
             let l_strike = center_strike - STRIKE_WIDTH_WIDE;
-            
-            let u_item = data.iter().find(|d| (d.strike_price - u_strike).abs() < 1.0);
-            let l_item = data.iter().find(|d| (d.strike_price - l_strike).abs() < 1.0);
-            
+
+            let u_item = data
+                .iter()
+                .find(|d| (d.strike_price - u_strike).abs() < 1.0);
+            let l_item = data
+                .iter()
+                .find(|d| (d.strike_price - l_strike).abs() < 1.0);
+
             if let (Some(u), Some(l)) = (u_item, l_item) {
                 let c_call = Self::get_price(center_item, OptionType::Call)?;
                 let c_put = Self::get_price(center_item, OptionType::Put)?;
                 let u_call = Self::get_price(u, OptionType::Call)?;
                 let l_put = Self::get_price(l, OptionType::Put)?;
-                
+
                 let mut pos = Vec::new();
-                pos.push(Position { strike: center_strike, kind: OptionType::Call, qty: -1, entry_price: c_call });
-                pos.push(Position { strike: center_strike, kind: OptionType::Put, qty: -1, entry_price: c_put });
-                pos.push(Position { strike: u_strike, kind: OptionType::Call, qty: 1, entry_price: u_call });
-                pos.push(Position { strike: l_strike, kind: OptionType::Put, qty: 1, entry_price: l_put });
-                
+                pos.push(Position {
+                    strike: center_strike,
+                    kind: OptionType::Call,
+                    qty: -1,
+                    entry_price: c_call,
+                });
+                pos.push(Position {
+                    strike: center_strike,
+                    kind: OptionType::Put,
+                    qty: -1,
+                    entry_price: c_put,
+                });
+                pos.push(Position {
+                    strike: u_strike,
+                    kind: OptionType::Call,
+                    qty: 1,
+                    entry_price: u_call,
+                });
+                pos.push(Position {
+                    strike: l_strike,
+                    kind: OptionType::Put,
+                    qty: 1,
+                    entry_price: l_put,
+                });
+
                 Ok((pos, format!("Applied: {} ({})", label, center_strike)))
             } else {
                 Err("Error: Wings for Iron Butterfly not found".to_string())
@@ -182,23 +304,30 @@ impl StrategyBuilder {
         }
     }
 
-    fn build_iron_condor(data: &[OptionData], label: &str) -> Result<(Vec<Position>, String), String> {
+    fn build_iron_condor(
+        data: &[OptionData],
+        label: &str,
+    ) -> Result<(Vec<Position>, String), String> {
         let c_idx = Self::find_call_by_delta(data, DELTA_OTM_16);
         let p_idx = Self::find_put_by_delta(data, -DELTA_OTM_16);
-        
+
         if let (Some(ci), Some(pi)) = (c_idx, p_idx) {
             let sc_item = &data[ci];
             let sp_item = &data[pi];
-            
+
             let sc_strike = sc_item.strike_price;
             let sp_strike = sp_item.strike_price;
-            
+
             let lc_strike = sc_strike + STRIKE_WIDTH_WIDE;
             let lp_strike = sp_strike - STRIKE_WIDTH_WIDE;
-            
-            let lc_item = data.iter().find(|d| (d.strike_price - lc_strike).abs() < 1.0);
-            let lp_item = data.iter().find(|d| (d.strike_price - lp_strike).abs() < 1.0);
-            
+
+            let lc_item = data
+                .iter()
+                .find(|d| (d.strike_price - lc_strike).abs() < 1.0);
+            let lp_item = data
+                .iter()
+                .find(|d| (d.strike_price - lp_strike).abs() < 1.0);
+
             if let (Some(lc), Some(lp)) = (lc_item, lp_item) {
                 let sc_p = Self::get_price(sc_item, OptionType::Call)?;
                 let sp_p = Self::get_price(sp_item, OptionType::Put)?;
@@ -206,12 +335,35 @@ impl StrategyBuilder {
                 let lp_p = Self::get_price(lp, OptionType::Put)?;
 
                 let mut pos = Vec::new();
-                pos.push(Position { strike: sc_strike, kind: OptionType::Call, qty: -1, entry_price: sc_p });
-                pos.push(Position { strike: sp_strike, kind: OptionType::Put, qty: -1, entry_price: sp_p });
-                pos.push(Position { strike: lc_strike, kind: OptionType::Call, qty: 1, entry_price: lc_p });
-                pos.push(Position { strike: lp_strike, kind: OptionType::Put, qty: 1, entry_price: lp_p });
-                
-                Ok((pos, format!("Applied: {} ({}/{})", label, sp_strike, sc_strike)))
+                pos.push(Position {
+                    strike: sc_strike,
+                    kind: OptionType::Call,
+                    qty: -1,
+                    entry_price: sc_p,
+                });
+                pos.push(Position {
+                    strike: sp_strike,
+                    kind: OptionType::Put,
+                    qty: -1,
+                    entry_price: sp_p,
+                });
+                pos.push(Position {
+                    strike: lc_strike,
+                    kind: OptionType::Call,
+                    qty: 1,
+                    entry_price: lc_p,
+                });
+                pos.push(Position {
+                    strike: lp_strike,
+                    kind: OptionType::Put,
+                    qty: 1,
+                    entry_price: lp_p,
+                });
+
+                Ok((
+                    pos,
+                    format!("Applied: {} ({}/{})", label, sp_strike, sc_strike),
+                ))
             } else {
                 Err("Error: Wings for Iron Condor not found".to_string())
             }
@@ -224,10 +376,14 @@ impl StrategyBuilder {
 
     fn get_price(data: &OptionData, kind: OptionType) -> Result<f64, String> {
         match kind {
-            OptionType::Call => data.call_options.as_ref()
+            OptionType::Call => data
+                .call_options
+                .as_ref()
                 .map(|o| o.market_data.ltp)
                 .ok_or_else(|| format!("Call data missing for strike {}", data.strike_price)),
-            OptionType::Put => data.put_options.as_ref()
+            OptionType::Put => data
+                .put_options
+                .as_ref()
                 .map(|o| o.market_data.ltp)
                 .ok_or_else(|| format!("Put data missing for strike {}", data.strike_price)),
         }
@@ -236,49 +392,71 @@ impl StrategyBuilder {
     fn find_call_by_delta(data: &[OptionData], target: f64) -> Option<usize> {
         Self::find_with_filter(data, target, OptionType::Call, |spread, delta| {
             // Basic quality filter
-             spread <= MAX_SPREAD && delta > 0.05 && delta < 0.95
+            spread <= MAX_SPREAD && delta > 0.05 && delta < 0.95
         })
     }
 
     fn find_put_by_delta(data: &[OptionData], target: f64) -> Option<usize> {
-         Self::find_with_filter(data, target, OptionType::Put, |spread, delta| {
-             spread <= MAX_SPREAD && delta > -0.95 && delta < -0.05
-         })
+        Self::find_with_filter(data, target, OptionType::Put, |spread, delta| {
+            spread <= MAX_SPREAD && delta > -0.95 && delta < -0.05
+        })
     }
 
-    fn find_with_filter<F>(data: &[OptionData], target: f64, kind: OptionType, filter: F) -> Option<usize>
-    where F: Fn(f64, f64) -> bool 
+    fn find_with_filter<F>(
+        data: &[OptionData],
+        target: f64,
+        kind: OptionType,
+        filter: F,
+    ) -> Option<usize>
+    where
+        F: Fn(f64, f64) -> bool,
     {
-        data.iter().enumerate()
-            .filter(|(_, d)| {
-                match kind {
-                    OptionType::Call => {
-                         if let Some(opt) = &d.call_options {
-                            let spread = (opt.market_data.ask_price - opt.market_data.bid_price).abs();
-                            let delta = opt.option_greeks.as_ref().map(|g| g.delta).unwrap_or(0.0);
-                            filter(spread, delta)
-                        } else { false }
-                    },
-                    OptionType::Put => {
-                        if let Some(opt) = &d.put_options {
-                            let spread = (opt.market_data.ask_price - opt.market_data.bid_price).abs();
-                            let delta = opt.option_greeks.as_ref().map(|g| g.delta).unwrap_or(0.0);
-                            filter(spread, delta)
-                        } else { false }
+        data.iter()
+            .enumerate()
+            .filter(|(_, d)| match kind {
+                OptionType::Call => {
+                    if let Some(opt) = &d.call_options {
+                        let spread = (opt.market_data.ask_price - opt.market_data.bid_price).abs();
+                        let delta = opt.option_greeks.as_ref().map(|g| g.delta).unwrap_or(0.0);
+                        filter(spread, delta)
+                    } else {
+                        false
+                    }
+                }
+                OptionType::Put => {
+                    if let Some(opt) = &d.put_options {
+                        let spread = (opt.market_data.ask_price - opt.market_data.bid_price).abs();
+                        let delta = opt.option_greeks.as_ref().map(|g| g.delta).unwrap_or(0.0);
+                        filter(spread, delta)
+                    } else {
+                        false
                     }
                 }
             })
             .min_by(|(_, a), (_, b)| {
                 let get_delta = |item: &OptionData| -> f64 {
                     match kind {
-                        OptionType::Call => item.call_options.as_ref().and_then(|o| o.option_greeks.as_ref()).map(|g| g.delta).unwrap_or(0.0),
-                        OptionType::Put => item.put_options.as_ref().and_then(|o| o.option_greeks.as_ref()).map(|g| g.delta).unwrap_or(0.0),
+                        OptionType::Call => item
+                            .call_options
+                            .as_ref()
+                            .and_then(|o| o.option_greeks.as_ref())
+                            .map(|g| g.delta)
+                            .unwrap_or(0.0),
+                        OptionType::Put => item
+                            .put_options
+                            .as_ref()
+                            .and_then(|o| o.option_greeks.as_ref())
+                            .map(|g| g.delta)
+                            .unwrap_or(0.0),
                     }
                 };
-                
+
                 let da = get_delta(a);
                 let db = get_delta(b);
-                (da - target).abs().partial_cmp(&(db - target).abs()).unwrap_or(Ordering::Equal)
+                (da - target)
+                    .abs()
+                    .partial_cmp(&(db - target).abs())
+                    .unwrap_or(Ordering::Equal)
             })
             .map(|(i, _)| i)
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,7 +5,10 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
-use std::{io::{self, Stdout}, time::{Duration, Instant}};
+use std::{
+    io::{self, Stdout},
+    time::{Duration, Instant},
+};
 use tokio::sync::{mpsc, watch};
 
 use crate::app::{self, App};
@@ -35,9 +38,9 @@ impl Tui {
     pub async fn run(
         &mut self,
         app: &mut App,
-        mut rx: mpsc::Receiver<TuiMessage>,      // Changed from Vec<OptionData>
+        mut rx: mpsc::Receiver<TuiMessage>, // Changed from Vec<OptionData>
         expiry_tx: watch::Sender<String>,
-        quote_tx: mpsc::Sender<String>           // [NEW] Channel to request quotes
+        quote_tx: mpsc::Sender<String>, // [NEW] Channel to request quotes
     ) -> Result<()> {
         let tick_rate = Duration::from_millis(250);
         let mut last_tick = Instant::now();
@@ -56,11 +59,17 @@ impl Tui {
                         let mut selection_changed = false;
 
                         if app.show_help {
-                             match key.code {
-                                KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => app.toggle_help(),
-                                KeyCode::Char('s') | KeyCode::Char('S') if key.modifiers.contains(KeyModifiers::SHIFT) => app.toggle_help(),
+                            match key.code {
+                                KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => {
+                                    app.toggle_help()
+                                }
+                                KeyCode::Char('s') | KeyCode::Char('S')
+                                    if key.modifiers.contains(KeyModifiers::SHIFT) =>
+                                {
+                                    app.toggle_help()
+                                }
                                 _ => {}
-                             }
+                            }
                         } else if key.modifiers.contains(KeyModifiers::SHIFT) {
                             match key.code {
                                 KeyCode::Down => app.move_position_row(1),
@@ -68,20 +77,24 @@ impl Tui {
                                 KeyCode::Left => {
                                     // Switch to previous expiry
                                     if app.previous_expiry() {
-                                        if let Some(exp) = app.available_expiries.get(app.current_expiry_index) {
-                                            let _ = expiry_tx.send(exp.clone());
-                                            app.data.clear(); 
-                                        }
-                                    }
-                                },
-                                KeyCode::Right => { 
-                                    if app.next_expiry() {
-                                        if let Some(exp) = app.available_expiries.get(app.current_expiry_index) {
+                                        if let Some(exp) =
+                                            app.available_expiries.get(app.current_expiry_index)
+                                        {
                                             let _ = expiry_tx.send(exp.clone());
                                             app.data.clear();
                                         }
                                     }
-                                },
+                                }
+                                KeyCode::Right => {
+                                    if app.next_expiry() {
+                                        if let Some(exp) =
+                                            app.available_expiries.get(app.current_expiry_index)
+                                        {
+                                            let _ = expiry_tx.send(exp.clone());
+                                            app.data.clear();
+                                        }
+                                    }
+                                }
                                 KeyCode::Char('S') | KeyCode::Char('s') => app.toggle_help(),
                                 _ => {}
                             }
@@ -92,46 +105,46 @@ impl Tui {
                                         app::Focus::OptionChain => app::Focus::Strategies,
                                         app::Focus::Strategies => app::Focus::OptionChain,
                                     };
-                                },
-                                _ => {
-                                    match app.active_focus {
-                                        app::Focus::OptionChain => {
-                                            match key.code {
-                                                KeyCode::Char('q') => app.should_quit = true,
-                                                KeyCode::Char('b') | KeyCode::Char('B') => app.handle_trade_action(true),
-                                                KeyCode::Char('s') | KeyCode::Char('S') => app.handle_trade_action(false),
-                                                KeyCode::Char(' ') => app.toggle_selection(),
-                                                KeyCode::Delete | KeyCode::Backspace => app.delete_position(),
-                                                KeyCode::Down => {
-                                                    app.next_row();
-                                                    selection_changed = true;
-                                                },
-                                                KeyCode::Up => {
-                                                    app.previous_row();
-                                                    selection_changed = true;
-                                                },
-                                                KeyCode::Left | KeyCode::Right => {
-                                                    app.toggle_column();
-                                                    selection_changed = true;
-                                                },
-                                                KeyCode::Char('?') => app.toggle_help(),
-                                                _ => {}
-                                            }
-                                        },
-                                        app::Focus::Strategies => {
-                                            match key.code {
-                                                KeyCode::Char('q') => app.should_quit = true,
-                                                KeyCode::Down => app.next_strategy(),
-                                                KeyCode::Up => app.previous_strategy(),
-                                                KeyCode::Char('?') => app.toggle_help(),
-                                                _ => {}
-                                            }
-                                        }
-                                    }
                                 }
+                                _ => match app.active_focus {
+                                    app::Focus::OptionChain => match key.code {
+                                        KeyCode::Char('q') => app.should_quit = true,
+                                        KeyCode::Char('b') | KeyCode::Char('B') => {
+                                            app.handle_trade_action(true)
+                                        }
+                                        KeyCode::Char('s') | KeyCode::Char('S') => {
+                                            app.handle_trade_action(false)
+                                        }
+                                        KeyCode::Char(' ') => app.toggle_selection(),
+                                        KeyCode::Delete | KeyCode::Backspace => {
+                                            app.delete_position()
+                                        }
+                                        KeyCode::Down => {
+                                            app.next_row();
+                                            selection_changed = true;
+                                        }
+                                        KeyCode::Up => {
+                                            app.previous_row();
+                                            selection_changed = true;
+                                        }
+                                        KeyCode::Left | KeyCode::Right => {
+                                            app.toggle_column();
+                                            selection_changed = true;
+                                        }
+                                        KeyCode::Char('?') => app.toggle_help(),
+                                        _ => {}
+                                    },
+                                    app::Focus::Strategies => match key.code {
+                                        KeyCode::Char('q') => app.should_quit = true,
+                                        KeyCode::Down => app.next_strategy(),
+                                        KeyCode::Up => app.previous_strategy(),
+                                        KeyCode::Char('?') => app.toggle_help(),
+                                        _ => {}
+                                    },
+                                },
                             }
                         }
-                        
+
                         // [NEW] Trigger Quote Fetch if selection changed
                         if selection_changed {
                             if let Some(instr_key) = app.get_selected_instrument_key() {
@@ -153,15 +166,26 @@ impl Tui {
                     TuiMessage::OptionChain(new_data) => {
                         app.data = new_data;
                         app.update_live_prices();
-                        
+
                         // Auto-center on ATM if first load
                         if !app.initial_centering_done && !app.data.is_empty() {
-                            let spot_price = app.data.first().map(|d| d.underlying_spot_price).unwrap_or(0.0);
-                            let closest = app.data.iter().enumerate().min_by(|(_, a), (_, b)| {
-                                let diff_a = (a.strike_price - spot_price).abs();
-                                let diff_b = (b.strike_price - spot_price).abs();
-                                diff_a.partial_cmp(&diff_b).unwrap_or(std::cmp::Ordering::Equal)
-                            }).map(|(i, _)| i);
+                            let spot_price = app
+                                .data
+                                .first()
+                                .map(|d| d.underlying_spot_price)
+                                .unwrap_or(0.0);
+                            let closest = app
+                                .data
+                                .iter()
+                                .enumerate()
+                                .min_by(|(_, a), (_, b)| {
+                                    let diff_a = (a.strike_price - spot_price).abs();
+                                    let diff_b = (b.strike_price - spot_price).abs();
+                                    diff_a
+                                        .partial_cmp(&diff_b)
+                                        .unwrap_or(std::cmp::Ordering::Equal)
+                                })
+                                .map(|(i, _)| i);
 
                             if let Some(idx) = closest {
                                 app.selected_row = idx;
@@ -177,7 +201,7 @@ impl Tui {
                         if let Some(instr_key) = app.get_selected_instrument_key() {
                             let _ = quote_tx.send(instr_key).await;
                         }
-                    },
+                    }
                     TuiMessage::Quote(quote_data) => {
                         app.market_depth = Some(quote_data);
                     }

--- a/src/ui/bid_ask.rs
+++ b/src/ui/bid_ask.rs
@@ -1,11 +1,11 @@
+use crate::app::App;
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect, Alignment},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
-    text::{Span, Line},
-    widgets::{Block, Borders, Paragraph, Table, Cell, Row},
+    text::{Line, Span},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table},
     Frame,
 };
-use crate::app::App;
 
 pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
@@ -25,54 +25,78 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
             ])
             .split(inner_area);
 
-         // 1. Header Info
-        let header_text = vec![
-            Line::from(vec![
-                Span::styled(format!("{} ", depth_data.symbol), Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw("LTP: "),
-                Span::styled(format!("{:.2} ", depth_data.last_price), Style::default().fg(Color::Cyan)),
-                Span::raw("Vol: "),
-                Span::styled(format!("{} ", depth_data.volume), Style::default().fg(Color::Gray)),
-            ])
-        ];
-        f.render_widget(Paragraph::new(header_text).alignment(Alignment::Center), chunks[0]);
+        // 1. Header Info
+        let header_text = vec![Line::from(vec![
+            Span::styled(
+                format!("{} ", depth_data.symbol),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("LTP: "),
+            Span::styled(
+                format!("{:.2} ", depth_data.last_price),
+                Style::default().fg(Color::Cyan),
+            ),
+            Span::raw("Vol: "),
+            Span::styled(
+                format!("{} ", depth_data.volume),
+                Style::default().fg(Color::Gray),
+            ),
+        ])];
+        f.render_widget(
+            Paragraph::new(header_text).alignment(Alignment::Center),
+            chunks[0],
+        );
 
         // 2. Depth Table
         // We will show Buy (Bid) on Left, Sell (Ask) on Right
-        let header_style = Style::default().add_modifier(Modifier::BOLD).fg(Color::DarkGray);
+        let header_style = Style::default()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::DarkGray);
         let header_cells = ["Qty", "Bid", "Ask", "Qty"]
             .iter()
             .map(|h| Cell::from(*h).style(header_style));
-        
+
         // Find max depth layer and max quantity for scaling
         let max_rows = usize::max(depth_data.depth.buy.len(), depth_data.depth.sell.len());
-        
-        let max_qty_buy = depth_data.depth.buy.iter().map(|d| d.quantity).max().unwrap_or(1) as f64;
-        let max_qty_sell = depth_data.depth.sell.iter().map(|d| d.quantity).max().unwrap_or(1) as f64;
+
+        let max_qty_buy = depth_data
+            .depth
+            .buy
+            .iter()
+            .map(|d| d.quantity)
+            .max()
+            .unwrap_or(1) as f64;
+        let max_qty_sell = depth_data
+            .depth
+            .sell
+            .iter()
+            .map(|d| d.quantity)
+            .max()
+            .unwrap_or(1) as f64;
         let max_qty = f64::max(max_qty_buy, max_qty_sell).max(1.0);
 
-        let cell_width = 8; 
-        
+        let cell_width = 8;
+
         // Overlap Colors
         // Darker backgrounds for the bars so white text pops
-        let bid_bg = Color::Rgb(40, 80, 40);   // Dark Green BG
-        let ask_bg = Color::Rgb(80, 40, 40);   // Dark Red BG
+        let bid_bg = Color::Rgb(40, 80, 40); // Dark Green BG
+        let ask_bg = Color::Rgb(80, 40, 40); // Dark Red BG
         let text_fg = Color::White;
 
         let mut rows = Vec::new();
         for i in 0..max_rows {
             let buy = depth_data.depth.buy.get(i);
             let sell = depth_data.depth.sell.get(i);
-            
+
             // Buy Side
             let (buy_cell, buy_price_cell) = if let Some(b) = buy {
                 let ratio = (b.quantity as f64 / max_qty).min(1.0);
                 let bar_len = (ratio * cell_width as f64).round() as usize;
-                
+
                 // Format: Right aligned number "    1200"
                 // Bar grows Left -> Right (Inwards to Price at Col 1)
-                let text = format!("{:>width$}", b.quantity, width=cell_width);
-                
+                let text = format!("{:>width$}", b.quantity, width = cell_width);
+
                 // Split text into two spans: [Bar Coverage] + [Rest]
                 // Since bar grows L->R: 0..bar_len has BG.
                 let (part1, part2) = if bar_len >= cell_width {
@@ -81,17 +105,18 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                     text.split_at(bar_len)
                 };
 
-                let span1 = Span::styled(part1.to_string(), Style::default().bg(bid_bg).fg(text_fg));
+                let span1 =
+                    Span::styled(part1.to_string(), Style::default().bg(bid_bg).fg(text_fg));
                 let span2 = Span::styled(part2.to_string(), Style::default().fg(Color::DarkGray)); // Empty part dim
-                
+
                 (
                     Cell::from(Line::from(vec![span1, span2])),
-                    Cell::from(format!("{:.2}", b.price)).style(Style::default().fg(Color::Green))
+                    Cell::from(format!("{:.2}", b.price)).style(Style::default().fg(Color::Green)),
                 )
             } else {
                 (Cell::from("-"), Cell::from("-"))
             };
-            
+
             // Sell Side
             let (sell_price_cell, sell_cell) = if let Some(s) = sell {
                 let ratio = (s.quantity as f64 / max_qty).min(1.0);
@@ -99,37 +124,45 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
                 // Format: Left aligned number "1200    "
                 // Bar grows Right -> Left (Inwards to Price at Col 2)
-                let text = format!("{:<width$}", s.quantity, width=cell_width);
-                
+                let text = format!("{:<width$}", s.quantity, width = cell_width);
+
                 // Split text: [Rest] + [Bar Coverage]
                 let split_idx = cell_width.saturating_sub(bar_len);
                 let (part1, part2) = text.split_at(split_idx);
-                
+
                 let span1 = Span::styled(part1.to_string(), Style::default().fg(Color::DarkGray)); // Empty part
-                let span2 = Span::styled(part2.to_string(), Style::default().bg(ask_bg).fg(text_fg)); // Bar part
-                
+                let span2 =
+                    Span::styled(part2.to_string(), Style::default().bg(ask_bg).fg(text_fg)); // Bar part
+
                 (
                     Cell::from(format!("{:.2}", s.price)).style(Style::default().fg(Color::Red)),
-                    Cell::from(Line::from(vec![span1, span2]))
+                    Cell::from(Line::from(vec![span1, span2])),
                 )
             } else {
                 (Cell::from("-"), Cell::from("-"))
             };
 
-            rows.push(Row::new(vec![buy_cell, buy_price_cell, sell_price_cell, sell_cell]));
+            rows.push(Row::new(vec![
+                buy_cell,
+                buy_price_cell,
+                sell_price_cell,
+                sell_cell,
+            ]));
         }
 
-        let table = Table::new(rows, [
-            Constraint::Percentage(25), 
-            Constraint::Percentage(25), 
-            Constraint::Percentage(25), 
-            Constraint::Percentage(25), 
-        ])
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+            ],
+        )
         .header(Row::new(header_cells).bottom_margin(0))
         .column_spacing(2);
 
         f.render_widget(table, chunks[1]);
-
     } else {
         let text = Paragraph::new("Loading Depth...")
             .style(Style::default().fg(Color::DarkGray))

--- a/src/ui/chart.rs
+++ b/src/ui/chart.rs
@@ -1,52 +1,68 @@
+use crate::app::App;
+use crate::strategy::StrategyStats;
 use ratatui::{
     layout::Rect,
     style::{Color, Style},
-    text::Span,
-    widgets::{Block, Borders, Chart, Axis, Dataset, GraphType},
     symbols,
+    text::Span,
+    widgets::{Axis, Block, Borders, Chart, Dataset, GraphType},
     Frame,
 };
-use crate::app::App;
-use crate::strategy::StrategyStats;
 
 pub fn draw(f: &mut Frame, app: &App, stats: &StrategyStats, area: Rect) {
-    let spot_price = app.data.first().map(|d| d.underlying_spot_price).unwrap_or(0.0);
-    
+    let spot_price = app
+        .data
+        .first()
+        .map(|d| d.underlying_spot_price)
+        .unwrap_or(0.0);
+
     // Default bounds if empty: Spot +/- 5%
-    let x_min = stats.points.first().map(|p| p.0).unwrap_or(spot_price * 0.95);
-    let x_max = stats.points.last().map(|p| p.0).unwrap_or(spot_price * 1.05);
+    let x_min = stats
+        .points
+        .first()
+        .map(|p| p.0)
+        .unwrap_or(spot_price * 0.95);
+    let x_max = stats
+        .points
+        .last()
+        .map(|p| p.0)
+        .unwrap_or(spot_price * 1.05);
 
     let x_labels = vec![
         Span::styled(format!("{:.0}", x_min), Style::default().fg(Color::Gray)),
         Span::styled(format!("{:.0}", x_max), Style::default().fg(Color::Gray)),
     ];
-    
+
     let y_min = stats.max_loss.min(0.0) * 1.1; // margin
     let y_max = stats.max_profit.max(0.0) * 1.1;
-    
+
     // If empty, y_min/max are 0.0. Give small range [-1000, 1000] for grid
-    let (y_min, y_max) = if app.portfolio.positions.is_empty() { (-1000.0, 1000.0) } else { (y_min, y_max) };
+    let (y_min, y_max) = if app.portfolio.positions.is_empty() {
+        (-1000.0, 1000.0)
+    } else {
+        (y_min, y_max)
+    };
 
     let zero_line_data = vec![(x_min, 0.0), (x_max, 0.0)];
     let spot_line_data = vec![(spot_price, y_min), (spot_price, y_max)];
 
     // Segment points into Profit (Green) and Loss (Red)
     let mut segments: Vec<(Vec<(f64, f64)>, Color)> = Vec::new();
-    
+
     if !stats.points.is_empty() {
         let mut current_segment = Vec::new();
         // Determine initial state: True if Green (>= 0), False if Red (< 0)
         let mut is_green = stats.points[0].1 >= 0.0;
-        
+
         current_segment.push(stats.points[0]);
 
         for i in 0..stats.points.len() - 1 {
             let p1 = stats.points[i];
-            let p2 = stats.points[i+1];
-            
+            let p2 = stats.points[i + 1];
+
             let p1_green = p1.1 >= 0.0;
             let p2_green = p2.1 >= 0.0;
-            
+
             if p1_green != p2_green {
                 // Crossing zero
                 // Interpolate x where y = 0
@@ -55,21 +71,27 @@ pub fn draw(f: &mut Frame, app: &App, stats: &StrategyStats, area: Rect) {
                 // x_zero = x1 - y1 / m = x1 - y1 * (x2 - x1) / (y2 - y1)
                 let x_zero = p1.0 - p1.1 * (p2.0 - p1.0) / (p2.1 - p1.1);
                 let p_zero = (x_zero, 0.0);
-                
+
                 // Finish current segment
                 current_segment.push(p_zero);
-                segments.push((current_segment, if is_green { Color::Green } else { Color::Red }));
-                
+                segments.push((
+                    current_segment,
+                    if is_green { Color::Green } else { Color::Red },
+                ));
+
                 // Start new segment
                 current_segment = Vec::new();
                 current_segment.push(p_zero);
                 is_green = !is_green; // Toggle state
             }
-            
+
             current_segment.push(p2);
         }
         // Push final segment
-        segments.push((current_segment, if is_green { Color::Green } else { Color::Red }));
+        segments.push((
+            current_segment,
+            if is_green { Color::Green } else { Color::Red },
+        ));
     }
 
     let mut datasets = vec![
@@ -93,28 +115,42 @@ pub fn draw(f: &mut Frame, app: &App, stats: &StrategyStats, area: Rect) {
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(*color))
-                .data(seg_data)
+                .data(seg_data),
         );
     }
-    
+
     // Helper removed, using crate::ui::format_indian_currency
 
     let chart = Chart::new(datasets)
-        .block(Block::default().title(" Payoff Graph ").borders(Borders::ALL))
-        .x_axis(Axis::default()
-            .title("Spot Price")
-            .style(Style::default().fg(Color::Gray))
-            .bounds([x_min, x_max])
-            .labels(x_labels))
-        .y_axis(Axis::default()
-            .title("P&L")
-            .style(Style::default().fg(Color::Gray))
-            .bounds([y_min, y_max])
-            .labels(vec![
-                Span::styled(crate::ui::format_indian_currency(y_min), Style::default().fg(Color::Gray)),
-                Span::styled("0", Style::default().fg(Color::Gray)),
-                Span::styled(crate::ui::format_indian_currency(y_max), Style::default().fg(Color::Gray)),
-            ]));
-    
+        .block(
+            Block::default()
+                .title(" Payoff Graph ")
+                .borders(Borders::ALL),
+        )
+        .x_axis(
+            Axis::default()
+                .title("Spot Price")
+                .style(Style::default().fg(Color::Gray))
+                .bounds([x_min, x_max])
+                .labels(x_labels),
+        )
+        .y_axis(
+            Axis::default()
+                .title("P&L")
+                .style(Style::default().fg(Color::Gray))
+                .bounds([y_min, y_max])
+                .labels(vec![
+                    Span::styled(
+                        crate::ui::format_indian_currency(y_min),
+                        Style::default().fg(Color::Gray),
+                    ),
+                    Span::styled("0", Style::default().fg(Color::Gray)),
+                    Span::styled(
+                        crate::ui::format_indian_currency(y_max),
+                        Style::default().fg(Color::Gray),
+                    ),
+                ]),
+        );
+
     f.render_widget(chart, area);
 }

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -1,27 +1,48 @@
+use crate::app::App;
+use ratatui::layout::Alignment;
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
-
     Frame,
 };
-use ratatui::layout::Alignment;
-use crate::app::App;
 
 // function removed
 
 // Redefining to match the calling pattern in mod.rs
 pub fn draw(f: &mut Frame, app: &App, area: Rect) {
-    let spot_price = app.data.first().map(|d| d.underlying_spot_price).unwrap_or(0.0);
-    let underlying = app.data.first()
-        .map(|d| d.underlying_key.split('|').next_back().unwrap_or(&d.underlying_key))
+    let spot_price = app
+        .data
+        .first()
+        .map(|d| d.underlying_spot_price)
+        .unwrap_or(0.0);
+    let underlying = app
+        .data
+        .first()
+        .map(|d| {
+            d.underlying_key
+                .split('|')
+                .next_back()
+                .unwrap_or(&d.underlying_key)
+        })
         .unwrap_or("NIFTY");
-    
+
     let mut spans = vec![
-        Span::styled(format!(" {} ", underlying), Style::default().bg(Color::Blue).fg(Color::White).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!(" {} ", underlying),
+            Style::default()
+                .bg(Color::Blue)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw(" "),
-        Span::styled(format!(" {:.2} ", spot_price), Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format!(" {:.2} ", spot_price),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw("  Exp: "), // Shortened label
     ];
 
@@ -32,28 +53,44 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
             if i > 0 {
                 spans.push(Span::raw(" "));
             }
-            
+
             let style = if i == app.current_expiry_index {
-                Style::default().bg(Color::Yellow).fg(Color::Black).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .bg(Color::Yellow)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::DarkGray)
             };
-            
+
             spans.push(Span::styled(format!(" {} ", expiry), style));
         }
     }
 
     spans.push(Span::raw("  |  Last: "));
-    spans.push(Span::styled(format!(" {} ", app.last_message), Style::default().bg(Color::DarkGray).fg(Color::White)));
+    spans.push(Span::styled(
+        format!(" {} ", app.last_message),
+        Style::default().bg(Color::DarkGray).fg(Color::White),
+    ));
 
     let dashboard_text = vec![
         Line::from(spans),
         Line::from(vec![
-            Span::styled("LIVE MARKET DATA", Style::default().fg(Color::Green).add_modifier(Modifier::RAPID_BLINK)), // subtle blinking
+            Span::styled(
+                "LIVE MARKET DATA",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::RAPID_BLINK),
+            ), // subtle blinking
             Span::raw(" • Press 'q' to quit • Arrow keys to navigate"),
             Span::raw(" • "),
-            Span::styled("Shortcuts: Shift + S", Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)),
-        ])
+            Span::styled(
+                "Shortcuts: Shift + S",
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
     ];
 
     let dashboard = Paragraph::new(dashboard_text)

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -1,52 +1,104 @@
+use crate::app::App;
 use ratatui::{
     layout::Constraint,
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, Cell, Row, Table},
     Frame,
 };
-use crate::app::App;
 
 pub fn draw(f: &mut Frame, app: &App) {
     if app.show_help {
         let area = crate::ui::centered_rect(60, 60, f.size());
         f.render_widget(ratatui::widgets::Clear, area);
-        
+
         let block = Block::default()
             .title(" Keyboard Shortcuts ")
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Cyan));
-        
+
         // Define rows
         let rows = vec![
-            Row::new(vec![Cell::from("GENERAL").style(Style::default().add_modifier(Modifier::BOLD).fg(Color::Blue)), Cell::from("")]),
-            Row::new(vec![Cell::from("Shift + S / ?"), Cell::from("Toggle this Help Guide")]),
+            Row::new(vec![
+                Cell::from("GENERAL").style(
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::Blue),
+                ),
+                Cell::from(""),
+            ]),
+            Row::new(vec![
+                Cell::from("Shift + S / ?"),
+                Cell::from("Toggle this Help Guide"),
+            ]),
             Row::new(vec![Cell::from("q"), Cell::from("Quit Application")]),
             Row::new(vec![Cell::from(""), Cell::from("")]), // Spacer
-
-            Row::new(vec![Cell::from("NAVIGATION").style(Style::default().add_modifier(Modifier::BOLD).fg(Color::Blue)), Cell::from("")]),
-            Row::new(vec![Cell::from("Arrow Keys"), Cell::from("Navigate Grid Cells")]),
-            Row::new(vec![Cell::from("Enter"), Cell::from("Select Row (if applicable)")]),
+            Row::new(vec![
+                Cell::from("NAVIGATION").style(
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::Blue),
+                ),
+                Cell::from(""),
+            ]),
+            Row::new(vec![
+                Cell::from("Arrow Keys"),
+                Cell::from("Navigate Grid Cells"),
+            ]),
+            Row::new(vec![
+                Cell::from("Enter"),
+                Cell::from("Select Row (if applicable)"),
+            ]),
             Row::new(vec![Cell::from(""), Cell::from("")]), // Spacer
-
-            Row::new(vec![Cell::from("TRADING").style(Style::default().add_modifier(Modifier::BOLD).fg(Color::Blue)), Cell::from("")]),
-            Row::new(vec![Cell::from("B"), Cell::from("Buy Active Selection (+1)")]),
-            Row::new(vec![Cell::from("S"), Cell::from("Sell Active Selection (-1)")]),
-            Row::new(vec![Cell::from("Delete / Backspace"), Cell::from("Remove Position at Selection")]),
+            Row::new(vec![
+                Cell::from("TRADING").style(
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::Blue),
+                ),
+                Cell::from(""),
+            ]),
+            Row::new(vec![
+                Cell::from("B"),
+                Cell::from("Buy Active Selection (+1)"),
+            ]),
+            Row::new(vec![
+                Cell::from("S"),
+                Cell::from("Sell Active Selection (-1)"),
+            ]),
+            Row::new(vec![
+                Cell::from("Delete / Backspace"),
+                Cell::from("Remove Position at Selection"),
+            ]),
             Row::new(vec![Cell::from(""), Cell::from("")]), // Spacer
-
-            Row::new(vec![Cell::from("POSITION MANAGEMENT").style(Style::default().add_modifier(Modifier::BOLD).fg(Color::Blue)), Cell::from("")]),
-            Row::new(vec![Cell::from("Space"), Cell::from("Select/Deselect Position for Multi-Move")]),
-            Row::new(vec![Cell::from("Shift + Arrow Up/Down"), Cell::from("Move Selected Position(s) Strike")]),
-            Row::new(vec![Cell::from("Shift + Arrow L/R"), Cell::from("Switch Expiry Date")]),
+            Row::new(vec![
+                Cell::from("POSITION MANAGEMENT").style(
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::Blue),
+                ),
+                Cell::from(""),
+            ]),
+            Row::new(vec![
+                Cell::from("Space"),
+                Cell::from("Select/Deselect Position for Multi-Move"),
+            ]),
+            Row::new(vec![
+                Cell::from("Shift + Arrow Up/Down"),
+                Cell::from("Move Selected Position(s) Strike"),
+            ]),
+            Row::new(vec![
+                Cell::from("Shift + Arrow L/R"),
+                Cell::from("Switch Expiry Date"),
+            ]),
         ];
 
-        let table = Table::new(rows, [
-            Constraint::Percentage(40),
-            Constraint::Percentage(60),
-        ])
+        let table = Table::new(
+            rows,
+            [Constraint::Percentage(40), Constraint::Percentage(60)],
+        )
         .block(block)
         .column_spacing(1);
-            
+
         f.render_widget(table, area);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,36 +1,32 @@
-pub mod dashboard;
-pub mod table;
-pub mod stats;
+pub mod bid_ask;
 pub mod chart;
+pub mod dashboard;
 pub mod help;
-pub mod strategies;
 pub mod setup;
-pub mod utils;
-pub mod bid_ask; // [NEW]
+pub mod stats;
+pub mod strategies;
+pub mod table;
+pub mod utils; // [NEW]
 
 pub use utils::{centered_rect, format_indian_currency};
 
+use crate::app::App;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     Frame,
 };
-use crate::app::App;
 
 pub fn draw(f: &mut Frame, app: &mut App) {
     let constraints = vec![
-        Constraint::Length(4), 
-        Constraint::Min(0), 
-        Constraint::Length(15)
+        Constraint::Length(4),
+        Constraint::Min(0),
+        Constraint::Length(15),
     ];
 
-    let chunks = Layout::default()
-        .constraints(constraints)
-        .split(f.size());
+    let chunks = Layout::default().constraints(constraints).split(f.size());
 
     // --- DASHBOARD ---
     dashboard::draw(f, app, chunks[0]);
-
-
 
     // --- MIDDLE SECTION (Table + Strategies + BidAsk) ---
     // Split chunks[1] into Table (75%) and Right Panel (25%)
@@ -41,7 +37,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
     // --- TABLE ---
     table::draw(f, app, middle_chunks[0]);
-    
+
     // --- RIGHT PANEL (Strategies + BidAsk) ---
     // Split right panel (middle_chunks[1]) vertically: 60% Strategies, 40% BidAsk
     let right_panel_chunks = Layout::default()
@@ -67,7 +63,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
         // Render Stats
         stats::draw(f, app, &stats, strategy_chunks[0]);
-        
+
         // Render Chart
         chart::draw(f, app, &stats, strategy_chunks[1]);
     }

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -27,10 +27,10 @@ pub async fn run_setup_tui(
                 .title(" Setup Trakbit ")
                 .borders(ratatui::widgets::Borders::ALL)
                 .border_style(ratatui::style::Style::default().fg(ratatui::style::Color::Cyan));
-            
+
             // Center the box - increased to 80/80 to prevent squashing on small terminals
             let area = crate::ui::centered_rect(80, 80, size);
-            
+
             let chunks = ratatui::layout::Layout::default()
                 .direction(ratatui::layout::Direction::Vertical)
                 .constraints([
@@ -48,27 +48,43 @@ pub async fn run_setup_tui(
             f.render_widget(block, area);
 
             let welcome = ratatui::widgets::Paragraph::new(vec![
-                ratatui::text::Line::from(ratatui::text::Span::styled("Welcome to Trakbit!", ratatui::style::Style::default().add_modifier(ratatui::style::Modifier::BOLD).fg(ratatui::style::Color::Magenta))),
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "Welcome to Trakbit!",
+                    ratatui::style::Style::default()
+                        .add_modifier(ratatui::style::Modifier::BOLD)
+                        .fg(ratatui::style::Color::Magenta),
+                )),
                 ratatui::text::Line::from("To get started, you need an Upstox Analytics Token."),
-                ratatui::text::Line::from(ratatui::text::Span::styled("(Valid for 1 year = no daily token generation!)", ratatui::style::Style::default().fg(ratatui::style::Color::Green))),
-            ]).alignment(ratatui::layout::Alignment::Center);
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "(Valid for 1 year = no daily token generation!)",
+                    ratatui::style::Style::default().fg(ratatui::style::Color::Green),
+                )),
+            ])
+            .alignment(ratatui::layout::Alignment::Center);
 
             let link_text = vec![
                 ratatui::text::Line::from("1. Go to:"),
-                ratatui::text::Line::from(ratatui::text::Span::styled("https://account.upstox.com/developer/apps#analytics", ratatui::style::Style::default().fg(ratatui::style::Color::Blue).add_modifier(ratatui::style::Modifier::UNDERLINED))),
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "https://account.upstox.com/developer/apps#analytics",
+                    ratatui::style::Style::default()
+                        .fg(ratatui::style::Color::Blue)
+                        .add_modifier(ratatui::style::Modifier::UNDERLINED),
+                )),
             ];
-            let link = ratatui::widgets::Paragraph::new(link_text).alignment(ratatui::layout::Alignment::Center);
+            let link = ratatui::widgets::Paragraph::new(link_text)
+                .alignment(ratatui::layout::Alignment::Center);
 
             let steps_text = vec![
                 ratatui::text::Line::from("2. Generate a new Analytics token"),
                 ratatui::text::Line::from("3. Copy 'Access Token' and paste below"),
             ];
-            let steps = ratatui::widgets::Paragraph::new(steps_text).alignment(ratatui::layout::Alignment::Center);
-            
+            let steps = ratatui::widgets::Paragraph::new(steps_text)
+                .alignment(ratatui::layout::Alignment::Center);
+
             let input_block = ratatui::widgets::Block::default()
                 .borders(ratatui::widgets::Borders::ALL)
                 .title(" Access Token ");
-            
+
             // Mask the token
             let masked_token: String = "*".repeat(token.len());
             // Safe width calc
@@ -77,7 +93,14 @@ pub async fn run_setup_tui(
                 String::new()
             } else if masked_token.len() > inner_width {
                 // Show the last N chars
-                masked_token.chars().rev().take(inner_width).collect::<String>().chars().rev().collect()
+                masked_token
+                    .chars()
+                    .rev()
+                    .take(inner_width)
+                    .collect::<String>()
+                    .chars()
+                    .rev()
+                    .collect()
             } else {
                 masked_token
             };
@@ -86,16 +109,36 @@ pub async fn run_setup_tui(
                 .style(ratatui::style::Style::default().fg(ratatui::style::Color::Yellow))
                 .block(input_block);
 
-            let demo_info = ratatui::widgets::Paragraph::new(
-                ratatui::text::Line::from(vec![ratatui::text::Span::raw("Or press "), ratatui::text::Span::styled("D", ratatui::style::Style::default().add_modifier(ratatui::style::Modifier::BOLD)), ratatui::text::Span::raw(" for Demo Mode")])
-            ).alignment(ratatui::layout::Alignment::Center);
+            let demo_info = ratatui::widgets::Paragraph::new(ratatui::text::Line::from(vec![
+                ratatui::text::Span::raw("Or press "),
+                ratatui::text::Span::styled(
+                    "D",
+                    ratatui::style::Style::default().add_modifier(ratatui::style::Modifier::BOLD),
+                ),
+                ratatui::text::Span::raw(" for Demo Mode"),
+            ]))
+            .alignment(ratatui::layout::Alignment::Center);
 
             let status_text = if is_validating {
-                ratatui::text::Line::from(ratatui::text::Span::styled("Validating token...", ratatui::style::Style::default().fg(ratatui::style::Color::Yellow)))
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    "Validating token...",
+                    ratatui::style::Style::default().fg(ratatui::style::Color::Yellow),
+                ))
             } else if error_msg.is_empty() {
-                ratatui::text::Line::from(vec![ratatui::text::Span::raw("Press "), ratatui::text::Span::styled("Enter", ratatui::style::Style::default().add_modifier(ratatui::style::Modifier::BOLD)), ratatui::text::Span::raw(" to continue")])
+                ratatui::text::Line::from(vec![
+                    ratatui::text::Span::raw("Press "),
+                    ratatui::text::Span::styled(
+                        "Enter",
+                        ratatui::style::Style::default()
+                            .add_modifier(ratatui::style::Modifier::BOLD),
+                    ),
+                    ratatui::text::Span::raw(" to continue"),
+                ])
             } else {
-                ratatui::text::Line::from(ratatui::text::Span::styled(format!("Error: {}", error_msg), ratatui::style::Style::default().fg(ratatui::style::Color::Red)))
+                ratatui::text::Line::from(ratatui::text::Span::styled(
+                    format!("Error: {}", error_msg),
+                    ratatui::style::Style::default().fg(ratatui::style::Color::Red),
+                ))
             };
 
             let status = ratatui::widgets::Paragraph::new(status_text)
@@ -107,18 +150,18 @@ pub async fn run_setup_tui(
             f.render_widget(input, chunks[3]);
             f.render_widget(demo_info, chunks[4]);
             f.render_widget(status, chunks[5]);
-
         })?;
 
         // If validating, logic is handled below after drawing "Validating..."
         // But we need to actually do the validation now if we set the flag in the previous loop iteration?
         // No, let's do it inline to keep it simple, but we need to re-draw for "Validating" to show up.
         // So we can set is_validating = true, re-draw, then validate.
-        
+
         if is_validating {
             // Perform validation
-             let client = reqwest::Client::new();
-             let res = client.get(validation_url)
+            let client = reqwest::Client::new();
+            let res = client
+                .get(validation_url)
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .header("Authorization", format!("Bearer {}", token.trim()))
@@ -133,13 +176,13 @@ pub async fn run_setup_tui(
                         // Check if data is not empty / valid API response structure if needed
                         // But status 200 is usually enough for auth check.
                         // Ideally we check if it returns proper JSON, but let's assume 200 means auth worked.
-                        break; 
+                        break;
                     } else if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-                         error_msg = "Invalid Access Token".to_string();
+                        error_msg = "Invalid Access Token".to_string();
                     } else {
-                         error_msg = format!("API Error: {}", response.status());
+                        error_msg = format!("API Error: {}", response.status());
                     }
-                },
+                }
                 Err(e) => {
                     error_msg = format!("Network/Request Error: {}", e);
                 }
@@ -147,14 +190,13 @@ pub async fn run_setup_tui(
             continue; // Re-loop to show result
         }
 
-
         let mut should_validate = false;
 
         if event::poll(Duration::from_millis(100))? {
             // Read first event strictly
             let first_event = event::read()?;
             let mut events = vec![first_event];
-            
+
             // Collect any other immediately available events (paste)
             while event::poll(Duration::from_millis(0))? {
                 events.push(event::read()?);
@@ -166,25 +208,29 @@ pub async fn run_setup_tui(
                         match key.code {
                             KeyCode::Char('d') | KeyCode::Char('D') if token.trim().is_empty() => {
                                 return Ok(SetupResult::Demo);
-                            },
+                            }
                             KeyCode::Char(c) => {
                                 token.push(c);
                                 error_msg.clear();
-                            },
+                            }
                             KeyCode::Backspace => {
                                 token.pop();
                                 error_msg.clear();
-                            },
+                            }
                             KeyCode::Enter => {
                                 if token.trim().is_empty() {
                                     error_msg = "Token cannot be empty".to_string();
                                 } else {
                                     should_validate = true;
                                 }
-                            },
+                            }
                             KeyCode::Esc => {
                                 disable_raw_mode()?;
-                                execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+                                execute!(
+                                    terminal.backend_mut(),
+                                    LeaveAlternateScreen,
+                                    DisableMouseCapture
+                                )?;
                                 terminal.show_cursor()?;
                                 return Err(anyhow::anyhow!("User cancelled setup"));
                             }
@@ -194,7 +240,7 @@ pub async fn run_setup_tui(
                 }
             }
         }
-        
+
         if should_validate {
             is_validating = true;
             // Next loop iteration will draw "Validating..." and then perform the check
@@ -209,17 +255,18 @@ pub async fn run_setup_tui(
 pub async fn load_and_validate_token(validation_url: &str) -> Option<String> {
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     let path = format!("{}/.trakbit_token", home);
-    
+
     if let Ok(saved_token) = std::fs::read_to_string(&path) {
         let saved_token = saved_token.trim().to_string();
         if !saved_token.is_empty() {
             let client = reqwest::Client::new();
-            if let Ok(res) = client.get(validation_url)
+            if let Ok(res) = client
+                .get(validation_url)
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .header("Authorization", format!("Bearer {}", saved_token))
                 .send()
-                .await 
+                .await
             {
                 if res.status().is_success() {
                     return Some(saved_token);

--- a/src/ui/stats.rs
+++ b/src/ui/stats.rs
@@ -1,3 +1,5 @@
+use crate::app::App;
+use crate::strategy::StrategyStats;
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
@@ -5,74 +7,122 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
-use crate::app::App;
-use crate::strategy::StrategyStats;
 
 pub fn draw(f: &mut Frame, app: &App, stats: &StrategyStats, area: Rect) {
     // Helper removed, using crate::ui::format_indian_currency
 
     let mut text = vec![
-        Line::from(Span::styled(" Strategy Builder ", Style::default().add_modifier(Modifier::BOLD).bg(Color::Blue).fg(Color::White))),
+        Line::from(Span::styled(
+            " Strategy Builder ",
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .bg(Color::Blue)
+                .fg(Color::White),
+        )),
         Line::from(""),
     ];
 
     // List Legs (Compact)
-    text.push(Line::from(Span::styled("Active Legs:", Style::default().add_modifier(Modifier::UNDERLINED))));
+    text.push(Line::from(Span::styled(
+        "Active Legs:",
+        Style::default().add_modifier(Modifier::UNDERLINED),
+    )));
     if app.portfolio.positions.is_empty() {
-        text.push(Line::from(Span::styled(" No active positions.", Style::default().fg(Color::DarkGray))));
-        text.push(Line::from(Span::styled(" Select strikes and press B/S to build.", Style::default().fg(Color::DarkGray))));
+        text.push(Line::from(Span::styled(
+            " No active positions.",
+            Style::default().fg(Color::DarkGray),
+        )));
+        text.push(Line::from(Span::styled(
+            " Select strikes and press B/S to build.",
+            Style::default().fg(Color::DarkGray),
+        )));
     }
     for pos in &app.portfolio.positions {
         let side = if pos.qty > 0 { "BUY" } else { "SELL" };
-        let color = if pos.qty > 0 { Color::Green } else { Color::Red };
+        let color = if pos.qty > 0 {
+            Color::Green
+        } else {
+            Color::Red
+        };
         let kind = match pos.kind {
-                crate::strategy::OptionType::Call => "CE",
-                crate::strategy::OptionType::Put => "PE",
+            crate::strategy::OptionType::Call => "CE",
+            crate::strategy::OptionType::Put => "PE",
         };
         text.push(Line::from(vec![
-            Span::styled(format!(" {:<4} ", side), Style::default().bg(color).fg(Color::Black)),
-            Span::raw(format!(" {} {} @ {:.1}", pos.qty.abs(), kind, pos.entry_price)),
-            Span::styled(format!("  Str: {:.0}", pos.strike), Style::default().fg(Color::Yellow)),
+            Span::styled(
+                format!(" {:<4} ", side),
+                Style::default().bg(color).fg(Color::Black),
+            ),
+            Span::raw(format!(
+                " {} {} @ {:.1}",
+                pos.qty.abs(),
+                kind,
+                pos.entry_price
+            )),
+            Span::styled(
+                format!("  Str: {:.0}", pos.strike),
+                Style::default().fg(Color::Yellow),
+            ),
         ]));
     }
-    
+
     let block = Block::default().borders(Borders::ALL).title(" Analysis ");
     if !app.portfolio.positions.is_empty() {
         // text.push(Line::from(""));
-        text.push(Line::from(Span::styled("Analysis:", Style::default().add_modifier(Modifier::UNDERLINED))));
-        
+        text.push(Line::from(Span::styled(
+            "Analysis:",
+            Style::default().add_modifier(Modifier::UNDERLINED),
+        )));
+
         let max_profit_s = if stats.max_profit_unlimited {
-                Span::styled("Unlimited", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD))
+            Span::styled(
+                "Unlimited",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )
         } else {
-                Span::styled(crate::ui::format_indian_currency(stats.max_profit), Style::default().fg(Color::Green))
+            Span::styled(
+                crate::ui::format_indian_currency(stats.max_profit),
+                Style::default().fg(Color::Green),
+            )
         };
 
         let max_loss_s = if stats.max_loss_unlimited {
-                Span::styled("Unlimited", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+            Span::styled(
+                "Unlimited",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            )
         } else {
-                Span::styled(crate::ui::format_indian_currency(stats.max_loss), Style::default().fg(Color::Red))
+            Span::styled(
+                crate::ui::format_indian_currency(stats.max_loss),
+                Style::default().fg(Color::Red),
+            )
         };
 
-        text.push(Line::from(vec![
-                Span::raw("Max Profit: "),
-                max_profit_s,
-        ]));
-        text.push(Line::from(vec![
-                Span::raw("Max Loss:   "),
-                max_loss_s,
-        ]));
+        text.push(Line::from(vec![Span::raw("Max Profit: "), max_profit_s]));
+        text.push(Line::from(vec![Span::raw("Max Loss:   "), max_loss_s]));
 
         if !stats.breakevens.is_empty() {
-                let be_str: Vec<String> = stats.breakevens.iter().map(|b| format!("{:.0}", b)).collect();
-                text.push(Line::from(vec![
-                    Span::raw("Breakeven:  "),
-                    Span::styled(be_str.join(", "), Style::default().fg(Color::Cyan)),
-                ]));
+            let be_str: Vec<String> = stats
+                .breakevens
+                .iter()
+                .map(|b| format!("{:.0}", b))
+                .collect();
+            text.push(Line::from(vec![
+                Span::raw("Breakeven:  "),
+                Span::styled(be_str.join(", "), Style::default().fg(Color::Cyan)),
+            ]));
         }
 
         text.push(Line::from(vec![
             Span::raw("Prob. of Profit: "),
-            Span::styled(format!("{:.1}%", stats.pop * 100.0), Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                format!("{:.1}%", stats.pop * 100.0),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
         ]));
     }
     let paragraph = Paragraph::new(text).block(block);

--- a/src/ui/strategies.rs
+++ b/src/ui/strategies.rs
@@ -1,17 +1,16 @@
+use crate::app::{App, Focus};
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, List, ListItem, ListState},
     Frame,
 };
-use crate::app::{App, Focus};
 
 pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
-    let items: Vec<ListItem> = app.strategies
+    let items: Vec<ListItem> = app
+        .strategies
         .iter()
-        .map(|s| {
-            ListItem::new(s.as_str()).style(Style::default().fg(Color::White))
-        })
+        .map(|s| ListItem::new(s.as_str()).style(Style::default().fg(Color::White)))
         .collect();
 
     // Determine Border Color based on Focus
@@ -22,14 +21,19 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     let items = List::new(items)
-        .block(Block::default().borders(Borders::ALL).title(" Strategies ").border_style(Style::default().fg(border_color)))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Strategies ")
+                .border_style(Style::default().fg(border_color)),
+        )
         .highlight_style(
             Style::default()
                 .bg(Color::White)
                 .fg(Color::Black)
                 .add_modifier(Modifier::BOLD),
         );
-        
+
     // We need a ListState to render selected item
     let mut state = ListState::default();
     state.select(Some(app.selected_strategy));

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -1,36 +1,49 @@
+use crate::app::{App, ColumnSelection};
 use ratatui::{
-    layout::{Constraint, Alignment},
+    layout::Rect,
+    layout::{Alignment, Constraint},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Cell, Row, Table},
     Frame,
-    layout::Rect,
 };
-use crate::app::{App, ColumnSelection};
 
 pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
-
-
-    let spot_price = app.data.first().map(|d| d.underlying_spot_price).unwrap_or(0.0);
+    let spot_price = app
+        .data
+        .first()
+        .map(|d| d.underlying_spot_price)
+        .unwrap_or(0.0);
 
     // Find ATM strike (closest to spot)
-    let closest_strike_index = app.data
+    let closest_strike_index = app
+        .data
         .iter()
         .enumerate()
         .min_by(|(_, a), (_, b)| {
             let diff_a = (a.strike_price - spot_price).abs();
             let diff_b = (b.strike_price - spot_price).abs();
-            diff_a.partial_cmp(&diff_b).unwrap_or(std::cmp::Ordering::Equal)
+            diff_a
+                .partial_cmp(&diff_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
         })
         .map(|(i, _)| i);
 
     // Calculate Max OI for scaling
     let max_oi = app.data.iter().fold(0.0f64, |acc, item| {
-        let call_oi = item.call_options.as_ref().map(|o| o.market_data.oi).unwrap_or(0.0);
-        let put_oi = item.put_options.as_ref().map(|o| o.market_data.oi).unwrap_or(0.0);
+        let call_oi = item
+            .call_options
+            .as_ref()
+            .map(|o| o.market_data.oi)
+            .unwrap_or(0.0);
+        let put_oi = item
+            .put_options
+            .as_ref()
+            .map(|o| o.market_data.oi)
+            .unwrap_or(0.0);
         acc.max(call_oi).max(put_oi)
     });
-    
+
     // Calculate available width for OI columns
     // Total width - Fixed columns (LTP 22*2 + Strike 10 + Delta 8*2 = 70) - Borders (2) - Spacing (6) = 78 overhead
     let overhead = 78;
@@ -39,39 +52,63 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
 
     // Bar drawing helper
     let draw_bar = |val: f64, max: f64, color: Color, grow_left: bool| -> Line {
-        if max == 0.0 { return Line::from(" ".repeat(max_bar_width)); }
-        let width = max_bar_width; 
+        if max == 0.0 {
+            return Line::from(" ".repeat(max_bar_width));
+        }
+        let width = max_bar_width;
         // User request: Highest OI should be 90% of the width
         let ratio = (val / max).min(1.0);
-        let filled = (ratio * width as f64 * 0.9).round() as usize; 
+        let filled = (ratio * width as f64 * 0.9).round() as usize;
         let empty = width - filled;
-        
-        let bar_char = "▆"; 
+
+        let bar_char = "▆";
         let bar_str = bar_char.repeat(filled);
         let empty_str = " ".repeat(empty);
-        
+
         let spans = if grow_left {
-             // Grow Left <- (e.g. "   |||")
-             vec![
-                 Span::raw(empty_str),
-                 Span::styled(bar_str, Style::default().fg(color).add_modifier(Modifier::DIM)),
-             ]
+            // Grow Left <- (e.g. "   |||")
+            vec![
+                Span::raw(empty_str),
+                Span::styled(
+                    bar_str,
+                    Style::default().fg(color).add_modifier(Modifier::DIM),
+                ),
+            ]
         } else {
-             // Grow Right -> (e.g. "|||   ")
-             vec![
-                 Span::styled(bar_str, Style::default().fg(color).add_modifier(Modifier::DIM)),
-                 Span::raw(empty_str),
-             ]
+            // Grow Right -> (e.g. "|||   ")
+            vec![
+                Span::styled(
+                    bar_str,
+                    Style::default().fg(color).add_modifier(Modifier::DIM),
+                ),
+                Span::raw(empty_str),
+            ]
         };
-        
+
         Line::from(spans)
     };
 
     let rows = app.data.iter().enumerate().map(|(i, item)| {
-        let call_ltp = item.call_options.as_ref().map(|o| o.market_data.ltp).unwrap_or(0.0);
-        let put_ltp = item.put_options.as_ref().map(|o| o.market_data.ltp).unwrap_or(0.0);
-        let call_oi = item.call_options.as_ref().map(|o| o.market_data.oi).unwrap_or(0.0);
-        let put_oi = item.put_options.as_ref().map(|o| o.market_data.oi).unwrap_or(0.0);
+        let call_ltp = item
+            .call_options
+            .as_ref()
+            .map(|o| o.market_data.ltp)
+            .unwrap_or(0.0);
+        let put_ltp = item
+            .put_options
+            .as_ref()
+            .map(|o| o.market_data.ltp)
+            .unwrap_or(0.0);
+        let call_oi = item
+            .call_options
+            .as_ref()
+            .map(|o| o.market_data.oi)
+            .unwrap_or(0.0);
+        let put_oi = item
+            .put_options
+            .as_ref()
+            .map(|o| o.market_data.oi)
+            .unwrap_or(0.0);
 
         let itm_call_bg = Color::Rgb(15, 40, 15);
         let itm_put_bg = Color::Rgb(40, 15, 15);
@@ -85,46 +122,86 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
         let is_call_itm = item.strike_price < spot_price;
         let is_put_itm = item.strike_price > spot_price;
 
-        if is_call_itm { call_style = call_style.bg(itm_call_bg); } else { call_style = call_style.fg(dim_text_color); }
-        if is_put_itm { put_style = put_style.bg(itm_put_bg); } else { put_style = put_style.fg(dim_text_color); }
+        if is_call_itm {
+            call_style = call_style.bg(itm_call_bg);
+        } else {
+            call_style = call_style.fg(dim_text_color);
+        }
+        if is_put_itm {
+            put_style = put_style.bg(itm_put_bg);
+        } else {
+            put_style = put_style.fg(dim_text_color);
+        }
 
         if Some(i) == closest_strike_index {
-             strike_style = strike_style.bg(Color::Blue).fg(Color::White).add_modifier(Modifier::BOLD);
+            strike_style = strike_style
+                .bg(Color::Blue)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD);
         }
 
         if i == app.selected_row {
             let sel_bg = Color::White;
             let sel_fg = Color::Black;
             match app.selected_column {
-                ColumnSelection::Call => { call_style = call_style.bg(sel_bg).fg(sel_fg).add_modifier(Modifier::BOLD); }
-                ColumnSelection::Put => { put_style = put_style.bg(sel_bg).fg(sel_fg).add_modifier(Modifier::BOLD); }
+                ColumnSelection::Call => {
+                    call_style = call_style
+                        .bg(sel_bg)
+                        .fg(sel_fg)
+                        .add_modifier(Modifier::BOLD);
+                }
+                ColumnSelection::Put => {
+                    put_style = put_style.bg(sel_bg).fg(sel_fg).add_modifier(Modifier::BOLD);
+                }
             }
             if strike_style.bg != Some(Color::Blue) {
-               strike_style = strike_style.bg(Color::DarkGray);
+                strike_style = strike_style.bg(Color::DarkGray);
             }
         }
 
         // Check selection for Call
-        // Note: Using format!("{:.0}") might be risky if we stored {:.2} in App. 
-        // Let's verify App usage. App uses {:.2}. 
+        // Note: Using format!("{:.0}") might be risky if we stored {:.2} in App.
+        // Let's verify App usage. App uses {:.2}.
         // Table display uses {:.0} for strike text, but the data is f64.
         // Let's match the key format used in App: format!("{:.2}", item.strike_price)
-        let call_key_exact = (format!("{:.2}", item.strike_price), crate::strategy::OptionType::Call);
+        let call_key_exact = (
+            format!("{:.2}", item.strike_price),
+            crate::strategy::OptionType::Call,
+        );
         if app.selected_positions.contains(&call_key_exact) {
-            call_style = call_style.bg(Color::DarkGray).add_modifier(Modifier::UNDERLINED);
+            call_style = call_style
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::UNDERLINED);
         }
 
-        let put_key_exact = (format!("{:.2}", item.strike_price), crate::strategy::OptionType::Put);
+        let put_key_exact = (
+            format!("{:.2}", item.strike_price),
+            crate::strategy::OptionType::Put,
+        );
         if app.selected_positions.contains(&put_key_exact) {
-             put_style = put_style.bg(Color::DarkGray).add_modifier(Modifier::UNDERLINED);
+            put_style = put_style
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::UNDERLINED);
         }
 
         // Apply Selection Style Override if this row is selected (re-apply to ensure it's on top of ITM colors)
         // Actually, we already did this above. The issue is `if i == app.selected_row` block is duplicated in original code.
         // I will just rely on the first block.
 
-        let call_qty = app.portfolio.positions.iter().find(|p| p.strike == item.strike_price && p.kind == crate::strategy::OptionType::Call).map(|p| p.qty).unwrap_or(0);
-        let put_qty = app.portfolio.positions.iter().find(|p| p.strike == item.strike_price && p.kind == crate::strategy::OptionType::Put).map(|p| p.qty).unwrap_or(0);
+        let call_qty = app
+            .portfolio
+            .positions
+            .iter()
+            .find(|p| p.strike == item.strike_price && p.kind == crate::strategy::OptionType::Call)
+            .map(|p| p.qty)
+            .unwrap_or(0);
+        let put_qty = app
+            .portfolio
+            .positions
+            .iter()
+            .find(|p| p.strike == item.strike_price && p.kind == crate::strategy::OptionType::Put)
+            .map(|p| p.qty)
+            .unwrap_or(0);
 
         // Helper to create badge spans
         let create_badge = |qty: i32| -> Span {
@@ -132,10 +209,13 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
             let label = if is_buy { "BUY" } else { "SELL" };
             let sign = if is_buy { "+" } else { "-" };
             let color = if is_buy { Color::Green } else { Color::Red };
-            
+
             Span::styled(
-                format!(" {}{} {} ", sign, qty.abs(), label), 
-                Style::default().bg(color).fg(Color::Black).add_modifier(Modifier::BOLD)
+                format!(" {}{} {} ", sign, qty.abs(), label),
+                Style::default()
+                    .bg(color)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
             )
         };
 
@@ -143,7 +223,7 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
             vec![
                 create_badge(call_qty),
                 Span::raw(" "),
-                Span::raw(format!("{:.2}", call_ltp))
+                Span::raw(format!("{:.2}", call_ltp)),
             ]
         } else {
             vec![Span::raw(format!("{:.2}", call_ltp))]
@@ -153,27 +233,44 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
             vec![
                 Span::raw(format!("{:.2}", put_ltp)),
                 Span::raw(" "),
-                create_badge(put_qty)
+                create_badge(put_qty),
             ]
         } else {
             vec![Span::raw(format!("{:.2}", put_ltp))]
         };
-        
+
         // Get Deltas (Prefer API value)
-        let call_delta = item.call_options.as_ref().and_then(|o| o.option_greeks.as_ref()).map(|g| g.delta).unwrap_or(0.0);
-        let put_delta = item.put_options.as_ref().and_then(|o| o.option_greeks.as_ref()).map(|g| g.delta).unwrap_or(0.0);
+        let call_delta = item
+            .call_options
+            .as_ref()
+            .and_then(|o| o.option_greeks.as_ref())
+            .map(|g| g.delta)
+            .unwrap_or(0.0);
+        let put_delta = item
+            .put_options
+            .as_ref()
+            .and_then(|o| o.option_greeks.as_ref())
+            .map(|g| g.delta)
+            .unwrap_or(0.0);
 
         // Point Inwards:
         // Left Column (Call OI): Grow Right -> (grow_left = false)
         // Right Column (Put OI): Grow Left <- (grow_left = true)
         Row::new(vec![
-            Cell::from(draw_bar(call_oi, max_oi, Color::Green, false).alignment(Alignment::Left)).style(call_style),
-            Cell::from(Line::from(format!("{:.2}", call_delta)).alignment(Alignment::Center)).style(call_style),
+            Cell::from(draw_bar(call_oi, max_oi, Color::Green, false).alignment(Alignment::Left))
+                .style(call_style),
+            Cell::from(Line::from(format!("{:.2}", call_delta)).alignment(Alignment::Center))
+                .style(call_style),
             Cell::from(Line::from(call_content).alignment(Alignment::Right)).style(call_style),
-            Cell::from(Line::from(format!("{:.0}", item.strike_price)).alignment(Alignment::Center)).style(strike_style),
+            Cell::from(
+                Line::from(format!("{:.0}", item.strike_price)).alignment(Alignment::Center),
+            )
+            .style(strike_style),
             Cell::from(Line::from(put_content).alignment(Alignment::Left)).style(put_style),
-            Cell::from(Line::from(format!("{:.2}", put_delta)).alignment(Alignment::Center)).style(put_style),
-            Cell::from(draw_bar(put_oi, max_oi, Color::Red, true).alignment(Alignment::Right)).style(put_style),
+            Cell::from(Line::from(format!("{:.2}", put_delta)).alignment(Alignment::Center))
+                .style(put_style),
+            Cell::from(draw_bar(put_oi, max_oi, Color::Red, true).alignment(Alignment::Right))
+                .style(put_style),
         ])
     });
 
@@ -184,29 +281,50 @@ pub fn draw(f: &mut Frame, app: &mut App, area: Rect) {
         Color::DarkGray
     };
 
-    let table = Table::new(rows, [
-        Constraint::Min(8),         // Call OI
-        Constraint::Length(8),      // Call Delta
-        Constraint::Length(22),     // Call LTP: Increased to fit badges
-        Constraint::Length(10),     // Strike
-        Constraint::Length(22),     // Put LTP: Increased to fit badges
-        Constraint::Length(8),      // Put Delta
-        Constraint::Min(8),         // Put OI
-    ])
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Min(8),     // Call OI
+            Constraint::Length(8),  // Call Delta
+            Constraint::Length(22), // Call LTP: Increased to fit badges
+            Constraint::Length(10), // Strike
+            Constraint::Length(22), // Put LTP: Increased to fit badges
+            Constraint::Length(8),  // Put Delta
+            Constraint::Min(8),     // Put OI
+        ],
+    )
     .header(
         Row::new(vec![
-            Cell::from(Line::from("OI").alignment(Alignment::Left)).style(Style::default().fg(Color::Green)),
-            Cell::from(Line::from("Delta").alignment(Alignment::Center)).style(Style::default().fg(Color::Green)), // slightly simpler color
-            Cell::from(Line::from("CALLS").alignment(Alignment::Right)).style(Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-            Cell::from(Line::from("STRIKE").alignment(Alignment::Center)).style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
-            Cell::from(Line::from("PUTS").alignment(Alignment::Left)).style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
-            Cell::from(Line::from("Delta").alignment(Alignment::Center)).style(Style::default().fg(Color::Red)),
-            Cell::from(Line::from("OI").alignment(Alignment::Right)).style(Style::default().fg(Color::Red)),
+            Cell::from(Line::from("OI").alignment(Alignment::Left))
+                .style(Style::default().fg(Color::Green)),
+            Cell::from(Line::from("Delta").alignment(Alignment::Center))
+                .style(Style::default().fg(Color::Green)), // slightly simpler color
+            Cell::from(Line::from("CALLS").alignment(Alignment::Right)).style(
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Cell::from(Line::from("STRIKE").alignment(Alignment::Center)).style(
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Cell::from(Line::from("PUTS").alignment(Alignment::Left))
+                .style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Cell::from(Line::from("Delta").alignment(Alignment::Center))
+                .style(Style::default().fg(Color::Red)),
+            Cell::from(Line::from("OI").alignment(Alignment::Right))
+                .style(Style::default().fg(Color::Red)),
         ])
         .bottom_margin(1)
-        .height(1)
+        .height(1),
     )
-    .block(Block::default().borders(Borders::ALL).border_style(Style::default().fg(border_color)).title(" Option Chain "))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color))
+            .title(" Option Chain "),
+    )
     .column_spacing(1);
 
     // Sync selection state with persisted TableState

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -25,27 +25,27 @@ pub fn format_indian_currency(val: f64) -> String {
     let abs_val = val.abs();
     let int_part = abs_val as u64;
     let s = int_part.to_string();
-    
+
     let len = s.len();
     let result = if len > 3 {
         let (remaining, last_three) = s.split_at(len - 3);
-        
+
         let mut groups = Vec::new();
         // Process remaining part in groups of 2 (reversed)
         // We use chars() to be safe, though these are digits.
         let r_chars: Vec<char> = remaining.chars().rev().collect();
-        
+
         for chunk in r_chars.chunks(2) {
             let g: String = chunk.iter().rev().collect();
             groups.push(g);
         }
         groups.reverse();
-        
+
         format!("{},{}", groups.join(","), last_three)
     } else {
         s
     };
-    
+
     let sign = if val < 0.0 { "-" } else { "" };
     format!("{}₹{}", sign, result)
 }


### PR DESCRIPTION
## Summary
- Run cargo fmt to fix formatting inconsistencies across all Rust files
- Addresses trailing whitespace, import ordering, and brace style issues
- All checks pass: cargo clippy, cargo check